### PR TITLE
Add arkiv-feedback skill

### DIFF
--- a/skills/arkiv-feedback/SKILL.md
+++ b/skills/arkiv-feedback/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: arkiv-feedback
+description: Submit a bug report or feature request to Arkiv-Network/reported-issues via an interactive walkthrough that mirrors the official GitHub issue forms. Use when the user wants to report an Arkiv bug, network issue, or product idea — keywords: report bug, file issue, Arkiv issue, network down, broken, not working, feature request, idea for Arkiv, suggest a change.
+---
+
+# Arkiv Feedback
+
+Walk the user through reporting a bug or feature request to [`Arkiv-Network/reported-issues`](https://github.com/Arkiv-Network/reported-issues), then submit it on their behalf — without making them touch GitHub's UI.
+
+The skill mirrors the two GitHub issue forms hosted on the repo (`1-bug.yml`, `2-feature-request.yml`). Keep the questions, options, and required/optional split aligned with those files. If they change, update `references/bug-form.md` and `references/feature-form.md`.
+
+## When to invoke
+
+Trigger on any of these signals from the user:
+
+- "I want to report a bug in Arkiv" / "file an issue" / "Arkiv is broken"
+- "the network is down" / "the SDK is throwing X" / "Kaolin/Braga is unreachable"
+- "I have an idea for Arkiv" / "I'd like a feature" / "Arkiv should support X"
+
+Do **not** invoke for:
+
+- General usage questions — point the user to the [Arkiv Discord](https://discord.gg/golem) or [docs](https://docs.arkiv.network) instead.
+- Issues with applications *built on* Arkiv — those go to the application's own team.
+- Security disclosures — those need the private channel; tell the user to email or open a private security advisory directly, do not file a public issue.
+
+## Flow
+
+```
+PARSE ARGS → PICK FORM → COLLECT FIELDS → DRAFT BODY → CONFIRM → SUBMIT (gh) | FALLBACK (file + URL) → OUTPUT
+```
+
+Run every step in order. Don't skip the confirmation step — this is a public repository, and a misfiled issue is awkward to clean up.
+
+### Step 1 — Parse args
+
+Recognise these inline flags if the user passes them:
+
+| Flag            | Meaning                                                 |
+|-----------------|---------------------------------------------------------|
+| `--bug`         | Use the bug form, skip the form-pick question           |
+| `--feature`     | Use the feature-request form, skip the form-pick question |
+| `--title TEXT`  | Pre-fill the issue title (without the `[Bug]:` / `[Idea]:` prefix) |
+| `--contact TEXT`| Pre-fill the contact field                              |
+| `--db-chain X`  | Pre-fill the DB-chain dropdown (bug only)               |
+| `--surface X`   | Pre-fill the Surface dropdown (bug only)                |
+| `--version X`   | Pre-fill the SDK/tool version field (bug only)          |
+| `--tx X`        | Pre-fill the transaction/entity ID field (bug only)     |
+
+Anything not provided inline is asked interactively. Anything provided is treated as authoritative; do not re-prompt.
+
+### Step 2 — Pick form
+
+If neither `--bug` nor `--feature` was set, ask the user:
+
+> Are you reporting **a bug or unexpected behaviour**, or **suggesting a feature or idea**?
+
+Single-choice. Don't assume defaults.
+
+### Step 3 — Collect fields
+
+Read `references/bug-form.md` or `references/feature-form.md` (whichever applies) and ask each field in order. Rules:
+
+- **Required fields** must be answered. If the user skips one, ask again — do not let an empty required field through.
+- **Dropdowns** are presented as numbered options. The user picks a number or types the value.
+- **Optional fields** can be skipped; if skipped, render them as `—` in the body.
+- **Multi-line fields** (logs, repro steps, "what happened?") let the user paste freely. Do not summarise or rewrite their input.
+- Don't editorialise. The maintainer triaging the report needs the user's words, not yours.
+
+### Step 4 — Draft body
+
+Compose the issue body in markdown, using the section structure in the relevant `references/*.md` template. Section headings must match the form labels exactly so triage sees the same shape regardless of whether the issue came through the form UI or this skill.
+
+Title:
+
+- Bug: `[Bug]: <one-line summary>`
+- Feature: `[Idea]: <one-line summary>`
+
+If the user didn't supply a one-line summary, ask for one before drafting — never auto-generate it.
+
+### Step 5 — Confirm
+
+Print the rendered title and body in full. Then ask:
+
+> Submit this to `Arkiv-Network/reported-issues`?
+
+If the user says no or wants to edit, loop back to the relevant field and re-ask. Do not submit without explicit confirmation.
+
+### Step 6 — Probe `gh`
+
+Decide which submission path to use:
+
+1. Run `command -v gh` to check the CLI is installed.
+2. If installed, run `gh auth status` to check the user is authenticated against `github.com`.
+
+If both succeed, take the happy path (Step 7). Otherwise, take the fallback (Step 8).
+
+### Step 7 — Submit (happy path)
+
+Write the rendered body to a temp file, then create the issue:
+
+```bash
+# Bug
+gh issue create \
+  --repo Arkiv-Network/reported-issues \
+  --title "[Bug]: <summary>" \
+  --body-file <draft-path> \
+  --label "bug,triage,reported-issue" \
+  --type bug
+
+# Feature
+gh issue create \
+  --repo Arkiv-Network/reported-issues \
+  --title "[Idea]: <summary>" \
+  --body-file <draft-path> \
+  --label "feature-request,triage,reported-issue"
+```
+
+Notes:
+
+- `--type bug` only works if the Arkiv-Network org has a `bug` issue type configured. If the call fails with an "issue type not found" error, retry the same command without `--type bug` — the `bug` label still applies.
+- The project-side workflow on [`Arkiv-Network/projects/4`](https://github.com/orgs/Arkiv-Network/projects/4/views/1) auto-adds every new issue from this repo. Do **not** call `gh project item-add` — it is unnecessary and creates duplicate items.
+
+On success, print the issue URL plus a one-line summary of what was filed.
+
+### Step 8 — Fallback (no `gh`)
+
+If `gh` is missing or not authenticated, do not try to install or authenticate it for the user. Instead:
+
+1. Save the rendered draft to `./arkiv-feedback-<timestamp>.md` (in the user's current working directory). Use the same section structure as the body — one heading per field — so the user can paste section by section.
+2. Print this hand-off, substituting the actual reason and path:
+
+   > Couldn't submit via `gh` (`<reason>`). Your draft is saved at `<path>`. Open <https://github.com/Arkiv-Network/reported-issues/issues/new/choose>, pick the matching form (bug or feature request), and paste each section into the corresponding field. The form will apply the right labels and routing on submit.
+
+3. Exit. Do not poll or watch for completion — the user finishes in the browser.
+
+## Hard rules
+
+- **Public repo.** Every issue is world-readable. Never paste secrets, private keys, internal URLs, or wallet seed phrases into the body. If the user provides any of these, redact them in the rendered body and warn the user.
+- **No security disclosures via this skill.** If the user describes anything that sounds like a vulnerability (auth bypass, key leak, signature forgery, RPC abuse), stop the flow and tell them to disclose privately rather than open a public issue.
+- **Don't editorialise.** Use the user's wording. Triage needs the original signal.
+- **One issue at a time.** If the user describes two unrelated problems, ask them to file separately.
+
+## See also
+
+- `references/bug-form.md` — bug form fields and body template
+- `references/feature-form.md` — feature-request form fields and body template
+- `arkiv-best-practices` skill — broader Arkiv context, SDK and entity model

--- a/skills/arkiv-feedback/SKILL.md
+++ b/skills/arkiv-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arkiv-feedback
-description: Submit a bug report or feature request to Arkiv-Network/reported-issues via an interactive walkthrough that mirrors the official GitHub issue forms. Use when the user wants to report an Arkiv bug, network issue, or product idea — keywords: report bug, file issue, Arkiv issue, network down, broken, not working, feature request, idea for Arkiv, suggest a change.
+description: Submit a bug report or feature request to Arkiv-Network/reported-issues via an interactive walkthrough that mirrors the official GitHub issue forms. Use when the user wants to report an Arkiv bug, a network issue, or a product idea. Keywords — report bug, file issue, Arkiv issue, network down, broken, not working, feature request, idea for Arkiv, suggest a change.
 ---
 
 # Arkiv Feedback
@@ -104,8 +104,7 @@ gh issue create \
   --repo Arkiv-Network/reported-issues \
   --title "[Bug]: <summary>" \
   --body-file <draft-path> \
-  --label "bug,triage,reported-issue" \
-  --type bug
+  --label "bug,triage,reported-issue"
 
 # Feature
 gh issue create \
@@ -117,7 +116,7 @@ gh issue create \
 
 Notes:
 
-- `--type bug` only works if the Arkiv-Network org has a `bug` issue type configured. If the call fails with an "issue type not found" error, retry the same command without `--type bug` — the `bug` label still applies.
+- Do not pass `--type bug` (or any `--type` flag). The widely-installed versions of `gh` (≤ 2.86.0) do not support it and the call fails with a usage error. The `bug` label is the source of truth for triage; org-level issue types, if used, can be assigned by maintainers after creation.
 - The project-side workflow on [`Arkiv-Network/projects/4`](https://github.com/orgs/Arkiv-Network/projects/4/views/1) auto-adds every new issue from this repo. Do **not** call `gh project item-add` — it is unnecessary and creates duplicate items.
 
 On success, print the issue URL plus a one-line summary of what was filed.

--- a/skills/arkiv-feedback/references/bug-form.md
+++ b/skills/arkiv-feedback/references/bug-form.md
@@ -6,7 +6,7 @@ Mirrors `Arkiv-Network/reported-issues/.github/ISSUE_TEMPLATE/1-bug.yml`. If tha
 
 - **Title prefix:** `[Bug]: `
 - **Labels (auto-applied on submit):** `bug`, `triage`, `reported-issue`
-- **Issue type:** `bug` (try first; fall back to no type if the org doesn't have it configured)
+- **Issue type:** not set via `gh` (the CLI version most users have doesn't support `--type`). The `bug` label is the canonical signal for triage.
 
 ## Fields, in order
 

--- a/skills/arkiv-feedback/references/bug-form.md
+++ b/skills/arkiv-feedback/references/bug-form.md
@@ -20,7 +20,7 @@ Ask each in this sequence. `R` = required, `O` = optional.
 | 4 | SDK / tool version             | Text      | O   | E.g. `@arkiv-network/sdk@0.6.5`.                                       |
 | 5 | What happened?                 | Multiline | R   | What they did, expected, and actually saw.                            |
 | 6 | Steps to reproduce             | Multiline | R   | Minimal repro a teammate could follow.                                |
-| 7 | Logs                           | Multiline | O   | Render inside a ` ```shell ... ``` ` block.                            |
+| 7 | Logs                           | Multiline | O   | Render inside a ` ```shell ... ``` ` block when provided.              |
 | 8 | Transaction / entity ID        | Text      | O   | If a specific tx hash or entity ID is involved.                       |
 | 9 | Anything else                  | Multiline | O   | Screenshots (link), recordings, links, extra context.                 |
 
@@ -42,11 +42,13 @@ Ask each in this sequence. `R` = required, `O` = optional.
 
 ## Body template
 
-Render the body exactly like this. Keep section headings verbatim. Use `—` for skipped optional fields.
+Render the body exactly like this. Keep section headings verbatim. For **skipped optional fields**, write `_No response_` on its own line — this matches what the GitHub form itself renders, so a skill-submitted issue is structurally indistinguishable from a form-submitted one.
+
+**Logs are special:** if the user provided logs, wrap them in a shell code fence. If they skipped, write `_No response_` on a single line and **omit the code fence entirely** — a placeholder inside a fence reads as code, which is wrong.
 
 ```markdown
 ### Contact
-{{contact-or-em-dash}}
+{{contact or "_No response_"}}
 
 ### DB-chain
 {{db-chain}}
@@ -55,7 +57,7 @@ Render the body exactly like this. Keep section headings verbatim. Use `—` for
 {{surface}}
 
 ### SDK / tool version
-{{version-or-em-dash}}
+{{version or "_No response_"}}
 
 ### What happened?
 {{what-happened}}
@@ -64,15 +66,20 @@ Render the body exactly like this. Keep section headings verbatim. Use `—` for
 {{repro}}
 
 ### Logs
-```shell
-{{logs-or-em-dash}}
-```
+{{
+  if logs provided:
+    ```shell
+    {{logs}}
+    ```
+  else:
+    _No response_
+}}
 
 ### Transaction / entity ID
-{{tx-or-em-dash}}
+{{tx or "_No response_"}}
 
 ### Anything else
-{{extra-or-em-dash}}
+{{extra or "_No response_"}}
 ```
 
 If the user pastes a stack trace or log output that contains a wallet private key, mnemonic, or any string that looks like a secret, **redact it** in the rendered body (replace with `[redacted]`) and warn the user before showing them the preview.

--- a/skills/arkiv-feedback/references/bug-form.md
+++ b/skills/arkiv-feedback/references/bug-form.md
@@ -1,0 +1,78 @@
+# Bug form — fields and body template
+
+Mirrors `Arkiv-Network/reported-issues/.github/ISSUE_TEMPLATE/1-bug.yml`. If that file changes, update this reference too.
+
+## Form metadata
+
+- **Title prefix:** `[Bug]: `
+- **Labels (auto-applied on submit):** `bug`, `triage`, `reported-issue`
+- **Issue type:** `bug` (try first; fall back to no type if the org doesn't have it configured)
+
+## Fields, in order
+
+Ask each in this sequence. `R` = required, `O` = optional.
+
+| # | Field                          | Type      | R/O | Notes                                                                 |
+|---|--------------------------------|-----------|-----|-----------------------------------------------------------------------|
+| 1 | Contact                        | Text      | O   | Discord handle, email, or GitHub username for follow-up.              |
+| 2 | DB-chain                       | Dropdown  | R   | Options below. Default to first if user is unsure.                    |
+| 3 | Surface                        | Dropdown  | R   | Options below.                                                        |
+| 4 | SDK / tool version             | Text      | O   | E.g. `@arkiv-network/sdk@0.6.5`.                                       |
+| 5 | What happened?                 | Multiline | R   | What they did, expected, and actually saw.                            |
+| 6 | Steps to reproduce             | Multiline | R   | Minimal repro a teammate could follow.                                |
+| 7 | Logs                           | Multiline | O   | Render inside a ` ```shell ... ``` ` block.                            |
+| 8 | Transaction / entity ID        | Text      | O   | If a specific tx hash or entity ID is involved.                       |
+| 9 | Anything else                  | Multiline | O   | Screenshots (link), recordings, links, extra context.                 |
+
+### DB-chain options
+
+1. Kaolin (testnet)
+2. Braga (testnet)
+3. Local / devnet
+4. Other (please describe in the steps)
+
+### Surface options
+
+1. SDK (`@arkiv-network/sdk`)
+2. CLI / tooling
+3. Block explorer
+4. Documentation
+5. Website
+6. Other
+
+## Body template
+
+Render the body exactly like this. Keep section headings verbatim. Use `—` for skipped optional fields.
+
+```markdown
+### Contact
+{{contact-or-em-dash}}
+
+### DB-chain
+{{db-chain}}
+
+### Surface
+{{surface}}
+
+### SDK / tool version
+{{version-or-em-dash}}
+
+### What happened?
+{{what-happened}}
+
+### Steps to reproduce
+{{repro}}
+
+### Logs
+```shell
+{{logs-or-em-dash}}
+```
+
+### Transaction / entity ID
+{{tx-or-em-dash}}
+
+### Anything else
+{{extra-or-em-dash}}
+```
+
+If the user pastes a stack trace or log output that contains a wallet private key, mnemonic, or any string that looks like a secret, **redact it** in the rendered body (replace with `[redacted]`) and warn the user before showing them the preview.

--- a/skills/arkiv-feedback/references/feature-form.md
+++ b/skills/arkiv-feedback/references/feature-form.md
@@ -20,23 +20,23 @@ Mirrors `Arkiv-Network/reported-issues/.github/ISSUE_TEMPLATE/2-feature-request.
 
 ## Body template
 
-Render the body exactly like this. Keep section headings verbatim. Use `—` for skipped optional fields.
+Render the body exactly like this. Keep section headings verbatim. For **skipped optional fields**, write `_No response_` on its own line — this matches what the GitHub form itself renders, so a skill-submitted issue is structurally indistinguishable from a form-submitted one.
 
 ```markdown
 ### Contact
-{{contact-or-em-dash}}
+{{contact or "_No response_"}}
 
 ### What problem are you trying to solve?
 {{problem}}
 
 ### What do you have in mind?
-{{proposal-or-em-dash}}
+{{proposal or "_No response_"}}
 
 ### What workarounds or alternatives have you considered?
-{{alternatives-or-em-dash}}
+{{alternatives or "_No response_"}}
 
 ### Anything else
-{{extra-or-em-dash}}
+{{extra or "_No response_"}}
 ```
 
 ## Triage hint for the agent

--- a/skills/arkiv-feedback/references/feature-form.md
+++ b/skills/arkiv-feedback/references/feature-form.md
@@ -1,0 +1,44 @@
+# Feature-request form — fields and body template
+
+Mirrors `Arkiv-Network/reported-issues/.github/ISSUE_TEMPLATE/2-feature-request.yml`. If that file changes, update this reference too.
+
+## Form metadata
+
+- **Title prefix:** `[Idea]: `
+- **Labels (auto-applied on submit):** `feature-request`, `triage`, `reported-issue`
+- **Issue type:** none (don't pass `--type` for features)
+
+## Fields, in order
+
+| # | Field                                       | Type      | R/O | Notes                                                                 |
+|---|---------------------------------------------|-----------|-----|-----------------------------------------------------------------------|
+| 1 | Contact                                     | Text      | O   | Discord handle, email, or GitHub username for follow-up.              |
+| 2 | What problem are you trying to solve?       | Multiline | R   | Lead with the user pain or use case, not the solution.                |
+| 3 | What do you have in mind?                   | Multiline | O   | Optional rough sketch of a solution. Don't push for completeness.     |
+| 4 | What workarounds or alternatives have you considered? | Multiline | O   | Anything tried, looked at, or ruled out.                              |
+| 5 | Anything else                               | Multiline | O   | Links, screenshots, related issues, extra context.                    |
+
+## Body template
+
+Render the body exactly like this. Keep section headings verbatim. Use `—` for skipped optional fields.
+
+```markdown
+### Contact
+{{contact-or-em-dash}}
+
+### What problem are you trying to solve?
+{{problem}}
+
+### What do you have in mind?
+{{proposal-or-em-dash}}
+
+### What workarounds or alternatives have you considered?
+{{alternatives-or-em-dash}}
+
+### Anything else
+{{extra-or-em-dash}}
+```
+
+## Triage hint for the agent
+
+If the user only has a vague idea and skips the problem field with something like "I dunno, just thought it'd be cool", push back gently and ask for the underlying use case before drafting. A feature request without a problem is hard to triage and will likely sit in the backlog. The user is better served by a five-minute Discord conversation first.


### PR DESCRIPTION
## Summary

- New `arkiv-feedback` skill: interactive walkthrough that mirrors the [GitHub issue forms](https://github.com/Arkiv-Network/reported-issues/tree/main/.github/ISSUE_TEMPLATE) in `Arkiv-Network/reported-issues` (bug + feature request) and submits on the user's behalf.
- Agent-agnostic by design — no Claude-Code-specific primitives. Should work in any runtime that supports the Anthropic Agent Skills spec.
- Happy path uses `gh issue create` with the right labels and (where available) the `bug` issue type. Falls back to saving a markdown draft locally + pointing the user at <https://github.com/Arkiv-Network/reported-issues/issues/new/choose> when `gh` is missing or unauthenticated.
- Field lists and body templates live in `references/bug-form.md` and `references/feature-form.md` — keep them in lockstep with the YAML form files in `reported-issues`.
- Project routing is **not** duplicated in the skill — the project workflow on `Arkiv-Network/projects/4` auto-adds new issues from the repo.

## Why

`reported-issues` structures community input well via the GitHub UI, but builders working inside an AI coding agent shouldn't have to context-switch to a browser to file a clean report. This skill closes that gap.