### PR TITLE
Update README with skill index

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,3 @@ npx skills add https://github.com/Arkiv-Network/skills --all
 ```
 
 Pass `-g` / `--global` to install at the user level instead of the current project. See `npx skills --help` for the full set of flags.
-
-## Contributing
-
-Each skill lives at `skills/<skill-name>/SKILL.md`, with optional `references/` for deeper docs the skill loads on demand. Keep skills agent-agnostic — no runtime-specific tool primitives — so they work everywhere the spec is supported.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,31 @@
 # Arkiv skills
 
-Agent skills for working with the Arkiv network. This includes best practices, code patterns, and reference documentation for both the SDK and JSON-RPC API.
+Agent skills for working with [Arkiv](https://arkiv.network) — the Web3 database, powered by $GLM. Each skill is framework-neutral and follows the [Anthropic Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) spec, so it runs in Claude Code, Cursor, Cline, Aider, and any other compatible runtime.
+
+## Available skills
+
+| Skill | What it does |
+|-------|--------------|
+| [`arkiv-best-practices`](skills/arkiv-best-practices) | Best practices, patterns, and practical examples for building on Arkiv. Covers the SDK, entities, attributes, queries, and expiration. |
+| [`arkiv-feedback`](skills/arkiv-feedback) | Walks the user through reporting a bug or feature request to [`Arkiv-Network/reported-issues`](https://github.com/Arkiv-Network/reported-issues), then submits it via `gh` (with a graceful fallback when `gh` isn't available). |
 
 ## Installation
 
+Install a single skill:
+
 ```bash
 npx skills add https://github.com/Arkiv-Network/skills --skill arkiv-best-practices
+npx skills add https://github.com/Arkiv-Network/skills --skill arkiv-feedback
 ```
+
+Install everything in this repo at once:
+
+```bash
+npx skills add https://github.com/Arkiv-Network/skills --all
+```
+
+Pass `-g` / `--global` to install at the user level instead of the current project. See `npx skills --help` for the full set of flags.
+
+## Contributing
+
+Each skill lives at `skills/<skill-name>/SKILL.md`, with optional `references/` for deeper docs the skill loads on demand. Keep skills agent-agnostic — no runtime-specific tool primitives — so they work everywhere the spec is supported.


### PR DESCRIPTION
## Summary

- Adds a skill index table listing both `arkiv-best-practices` and `arkiv-feedback` (the latter just merged via #4) so the README stays current.
- Notes that skills follow the Anthropic Agent Skills spec and run in any compatible runtime (Claude Code, Cursor, Cline, Aider, …).
- Documents install variants: per-skill (`--skill <name>`) and bulk (`--all`), with a pointer to `npx skills --help` for the rest.
- Adds a short Contributing section explaining the `skills/<name>/SKILL.md` layout.

## Why

The previous README only mentioned `arkiv-best-practices` and assumed a single skill in the repo. With `arkiv-feedback` merged the README needs to acknowledge multiple skills and explain how to install them individually or together.

## Test plan

- [x] Render the README on GitHub; confirm the table renders and links resolve
- [x] `npx skills add https://github.com/Arkiv-Network/skills --all` from a clean directory installs both skills