### PR TITLE
Update skills to new Tiramisu network + v0.8.x version of `@arkiv-network/sdk`

### DIFF
--- a/skills/arkiv-best-practices/SKILL.md
+++ b/skills/arkiv-best-practices/SKILL.md
@@ -33,14 +33,14 @@ An entity is a data record containing:
 Attributes are the backbone of querying. In SDK 0.8, attributes are passed as an **object keyed by name** (not an array):
 
 ```typescript
-import { i32, dec, str } from "@arkiv-network/sdk/attr"
+import { i32, u64, dec, str } from "@arkiv-network/sdk/attr"
 
 // Object form — each key is the attribute name
 attributes: {
   type: "note",              // bare string → str
   priority: i32(5),          // explicit i32 for range queries
   score: dec("4.5"),         // genuine decimal
-  created: i32(Date.now()),  // timestamp as i32
+  created: u64(Date.now()),  // timestamp as i32
 }
 ```
 
@@ -86,9 +86,11 @@ Arkiv provides a TypeScript SDK. For detailed SDK reference, read `references/sd
 ### TypeScript (Node.js / Bun)
 
 ```bash
-npm install @arkiv-network/sdk@dev viem
+npm install @arkiv-network/sdk viem
 # or
-bun add @arkiv-network/sdk@dev viem
+pnpm add @arkiv-network/sdk viem
+# or
+bun add @arkiv-network/sdk viem
 ```
 
 The SDK builds on [viem](https://viem.sh) and declares it as a **peer dependency**. Install `viem` alongside the SDK. The SDK no longer re-exports viem's internals — `http`, `custom`, `privateKeyToAccount`, `Hex`, etc. must be imported from `viem` / `viem/accounts` directly.
@@ -182,6 +184,13 @@ const entity = await publicClient.getEntity(entityKey)
 ```
 
 Available fields: `key`, `owner`, `creator`, `createdAt`, `updatedAt`, `expiresAt`, `creationFlags`, `contentType`, `payload`, `attributeSchema`, `attributes`.
+
+### Creation flags
+
+Set at entity creation only (`creationFlags` on create). Two flags matter in practice:
+
+- **`readonly`** — payload and attributes cannot be changed, even by the owner (only delete remains).
+- **`permissionlessExtension`** — any address can call `extendEntity()` on this entity, not just the owner.
 
 Pass the selection **inline**. A selection stored in a variable widens `true` to `boolean` and the result type can't be narrowed; if you must reuse one, annotate it `as const`.
 
@@ -301,7 +310,7 @@ const publicClient = createPublicClient({
 
 ### 3. Separate Read and Write Clients
 
-Always use `createPublicClient` for queries. It prevents accidental writes, doesn't require a private key, and is safe for frontend/public use. Reserve `createWalletClient` for backend services that need to create/patch/delete.
+Always use `createPublicClient` for queries. It prevents accidental writes, doesn't require a private key, and is safe for frontend/public use. Use `createWalletClient` only for write paths — backend services with a server-held key, or client-side via the user's injected wallet (MetaMask/wagmi).
 
 ### 4. Design Attributes for Queryability
 
@@ -553,7 +562,7 @@ entities.sort((a, b) => priorityOf(b) - priorityOf(a))
 
 When a project upgrades `@arkiv-network/sdk` from 0.7.x to 0.8.0-dev.3+, apply all of these together:
 
-1. **Install the dev release:** `npm install @arkiv-network/sdk@dev viem`.
+1. **Install the latest release:** `npm install @arkiv-network/sdk viem`.
 2. **Swap chain:** `braga` → `tiramisu` in all imports and client setup.
 3. **Fix imports:** import `ExpirationTime`, `jsonToPayload`, `stringToPayload` from `@arkiv-network/sdk` root (not `/utils`).
 4. **Attributes array → object:** `{ key: "type", value: "note" }` → `{ type: "note" }`.
@@ -575,7 +584,7 @@ Braga was retired on 12 August 2026. When a user wants to upgrade an existing Ar
 Follow this sequence:
 
 1. Read `references/migration-guide.md` before making edits.
-2. Install `@arkiv-network/sdk@dev` and apply the "Upgrading to SDK 0.8.0" checklist above.
+2. Install `@arkiv-network/sdk` and apply the "Upgrading to SDK 0.8.0" checklist above.
 3. Replace `braga` chain imports/usages with `tiramisu`.
 4. Update RPC URLs, WebSocket URLs, chain IDs, explorer links, faucet links, and wallet `nativeCurrency` (symbol `GLM`).
 5. Register an RPC API key at `https://hub.arkiv.network/api-keys`.
@@ -613,4 +622,4 @@ The `references/` directory contains detailed documentation for specific topics.
 - **`InvalidValueError` on a number** — Bare floats are rejected. Use `dec("19.99")` for decimals or `i32(1999)` for scaled integers.
 - **`NoEntityFoundError`** — The entity does not exist or has expired. Expiration fires no event in 0.8 — poll or query by `$expiresAt`.
 - **RPC rate limited** — Register an API key at `https://hub.arkiv.network/api-keys` and pass it in the RPC URL or as a header.
-- **Query parse error on `ne()`/`exists()`/`hasType()`** — These operators are exported by the SDK but not implemented on the node. Use `not(eq(...))` instead.
+- **Query parse error on `ne()`/`exists()`/`hasType()`** — These operators are exported by the SDK but not implemented on the node. For inequality, use `not(eq(...))` as the not-equal workaround (matches entities that never set the attribute). There is no substitute for `exists()` or `hasType()` today.

--- a/skills/arkiv-best-practices/SKILL.md
+++ b/skills/arkiv-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arkiv-best-practices
-description: Best practices, patterns, and practical examples for building applications with Arkiv — a decentralized Ethereum database with queryable, time-scoped storage. Use this skill whenever the user is working with Arkiv SDK, the @arkiv-network/sdk package, Arkiv entities, Arkiv queries, the select() query API, Arkiv attributes, ExpiresIn/expiration, the Braga testnet, or building any application that stores, queries, or manages data on the Arkiv network. Also use when the user mentions decentralized data storage on Ethereum, blockchain database, Web3 data storage, on-chain data, entity CRUD operations with expiration, arkiv_query, migrating an Arkiv project from Kaolin to Braga, or upgrading an Arkiv project to SDK 0.7.x (viem peer dependency, buildQuery to select migration, orderBy removal).
+description: Best practices, patterns, and practical examples for building applications with Arkiv — a decentralized Ethereum database with queryable, time-scoped storage. Use this skill whenever the user is working with Arkiv SDK, the @arkiv-network/sdk package, Arkiv entities, Arkiv queries, the select() query API, Arkiv attributes, typed attributes, dec(), Expiry/expiration, the Cheesecake devnet, patchEntity, executeBatch, watchEntityEvents, changeOwnership, or building any application that stores, queries, or manages data on the Arkiv network. Also use when the user mentions decentralized data storage on Ethereum, blockchain database, Web3 data storage, on-chain data, entity CRUD operations with expiration, arkiv_query, migrating an Arkiv project from Braga to Cheesecake, or upgrading an Arkiv project to SDK 0.8.
 ---
 
 # Arkiv Best Practices & Practical Examples
@@ -9,11 +9,13 @@ Arkiv is a decentralized data layer that brings queryable, time-scoped storage t
 
 ## Architecture Overview
 
-Arkiv uses three layers:
+Arkiv is **designed as three layers**:
 
 1. **Ethereum Mainnet** — Final settlement, proof verification, source of truth.
 2. **Arkiv Coordination Layer** — Data management, registry, cross-chain sync.
 3. **Specialized DB-Chains** — High-performance CRUD via JSON-RPC, indexed queries, programmable expiration.
+
+Nothing in the current source repos confirms the coordination layer or mainnet settlement is live on Cheesecake — treat the devnet as the active layer for now.
 
 ## Core Concepts
 
@@ -22,47 +24,58 @@ Arkiv uses three layers:
 An entity is a data record containing:
 
 - **Payload** — The actual data (JSON, text, binary)
-- **Attributes** — Key-value pairs for querying (string or numeric)
-- **ExpiresIn** — Automatic expiration measured in seconds (use `ExpirationTime` helpers)
+- **Attributes** — Key-value pairs for querying, with explicit types
+- **Expiry** — Automatic expiration via the `expires` parameter (use `ExpirationTime` helpers)
 - **Content Type** — MIME type of the payload
 
 ### Attributes
 
-Attributes are the backbone of querying. Use the right type for each attribute because it determines what query operators are available:
+Attributes are the backbone of querying. In SDK 0.8, attributes are passed as an **object keyed by name** (not an array):
 
 ```typescript
-// String attributes — support eq() equality checks
-{ key: 'type', value: 'note' }
-{ key: 'status', value: 'active' }
+import { i32, dec, str } from "@arkiv-network/sdk/attr"
 
-// Numeric attributes — support eq(), gt(), lt(), gte(), lte() range queries
-{ key: 'priority', value: 5 }
-{ key: 'created', value: Date.now() }
+// Object form — each key is the attribute name
+attributes: {
+  type: "note",              // bare string → str
+  priority: i32(5),          // explicit i32 for range queries
+  score: dec("4.5"),         // genuine decimal
+  created: i32(Date.now()),  // timestamp as i32
+}
 ```
 
-**Important:** If you store a number as a string (`{ key: 'priority', value: '5' }`), you lose the ability to do range queries with `gt()`, `lt()`, etc. Always use numeric values for attributes you plan to filter by range.
-
-**Important:** Numeric attribute values must be **integers**. A float like `19.99` throws an `InvalidAttributeError` (the SDK validates this client-side since 0.7.0). Scale non-integers to a fixed precision instead — store `19.99` as `1999` cents and divide on read.
-
-Glob pattern matching on string attributes (`~`) exists at the protocol level but is **not yet exposed in the TypeScript SDK** — if you need it, use the raw JSON-RPC API (see `references/api-reference.md`).
-
-### ExpiresIn
-
-Every entity has a lifespan expressed in **seconds**. Always use the `ExpirationTime` helper to convert human-readable durations — never hardcode raw numbers:
+When reading, `entity.attributes` is also an object keyed by name. Each value is `{ type, value }`:
 
 ```typescript
-import { ExpirationTime } from "@arkiv-network/sdk/utils";
-
-ExpirationTime.fromMinutes(30); // 1800 seconds
-ExpirationTime.fromHours(1); // 3600 seconds
-ExpirationTime.fromHours(12); // 43200 seconds
-ExpirationTime.fromHours(24); // 86400 seconds
-ExpirationTime.fromDays(7); // 604800 seconds
+entity.attributes.priority?.value  // 5
+entity.attributes.priority?.type   // "i32"
 ```
 
-**Important:** The `expiresIn` field takes a value in **seconds**. A raw number like `expiresIn: 3600` means 3600 seconds (1 hour). Always prefer `ExpirationTime.fromMinutes()`, `ExpirationTime.fromHours()`, or `ExpirationTime.fromDays()` for readability and to avoid mistakes.
+**Important:** If you store a number as a string (`type: "5"`), you lose the ability to do range queries with `gt()`, `lt()`, etc. Always use the correct typed helper for attributes you plan to filter by range.
 
-**Important:** Arkiv measures expiration in whole blocks (1 block = 2 seconds), so `expiresIn` must be a **positive integer and a multiple of 2** — otherwise the SDK throws an `InvalidExpirationError`. The `ExpirationTime` helpers always produce valid values, which is another reason to use them over raw numbers.
+**Important:** A bare float like `19.99` throws `InvalidValueError`. Use `dec("19.99")` for genuine decimals, or scale to an integer (`1999` cents) if you only need integer range queries.
+
+**Attribute name rules:** 1–32 bytes, start with a letter, chars `[A-Za-z0-9._-]`, no `$` prefix, no `--`, not a reserved word (`and`, `or`, `not`, `true`, `false`, `startswith`, `exists`, `typeof`, or any type tag). Max 32 attributes per operation.
+
+Prefix matching on string attributes is available via `startsWith()` in the TypeScript SDK and `STARTSWITH` in the raw JSON-RPC API (see `references/api-reference.md`).
+
+### Expiry
+
+Every entity has a lifespan expressed via the `expires` parameter. Always use the `ExpirationTime` helper — never hardcode raw numbers:
+
+```typescript
+import { ExpirationTime } from "@arkiv-network/sdk"
+
+ExpirationTime.fromMinutes(30)
+ExpirationTime.fromHours(1)
+ExpirationTime.fromHours(12)
+ExpirationTime.fromDays(7)
+ExpirationTime.fromWeeks(2)
+ExpirationTime.fromMonths(3)
+ExpirationTime.permanent()
+ExpirationTime.atBlock(1_200_000n)
+ExpirationTime.atDate(new Date("2027-01-01"))
+```
 
 Entities can be extended before they expire using `extendEntity()`. Over-allocating expiration wastes storage fees — start short and extend if needed.
 
@@ -73,138 +86,153 @@ Arkiv provides a TypeScript SDK. For detailed SDK reference, read `references/sd
 ### TypeScript (Node.js / Bun)
 
 ```bash
-npm install @arkiv-network/sdk viem
+npm install @arkiv-network/sdk@dev viem
 # or
-bun add @arkiv-network/sdk viem
+bun add @arkiv-network/sdk@dev viem
 ```
 
-The SDK builds on [viem](https://viem.sh) and declares it as a **peer dependency** since `0.7.0`, so install `viem` alongside the SDK. The SDK no longer re-exports viem's internals — `http`, `custom`, `privateKeyToAccount`, `Hex`, etc. must be imported from `viem` / `viem/accounts` directly.
+The SDK builds on [viem](https://viem.sh) and declares it as a **peer dependency**. Install `viem` alongside the SDK. The SDK no longer re-exports viem's internals — `http`, `custom`, `privateKeyToAccount`, `Hex`, etc. must be imported from `viem` / `viem/accounts` directly.
 
-**Check the installed SDK version before writing code** — the API differs across versions:
-
-- `0.7.0+` — viem is a peer dependency; query with `select()`; `orderBy`/`asc`/`desc` are deprecated no-ops.
-- `0.6.5` – `0.6.x` — `http`, `custom`, `privateKeyToAccount` import from the SDK itself (`@arkiv-network/sdk` and `@arkiv-network/sdk/accounts`); query with `buildQuery()` + `withPayload()`/`withAttributes()`/`withMetadata()`.
-- Below `0.6.5` — the `braga` chain export does not exist yet.
-
-Do not pin the install command unless the user explicitly asks for that; verify the currently installed version and upgrade only if needed. All examples below assume `0.7.0+`. If the project is on an older version, follow the "Upgrading to SDK 0.7.0" checklist later in this document.
+**Install the `@dev` tag** — npm `latest` is still 0.7.0, which targets the retired Braga network. All examples below assume `0.8.0-dev.3+`.
 
 Two client types exist:
 
-1. **WalletClient** (read/write) — Requires a private key. Use for creating, updating, deleting entities.
-2. **PublicClient** (read-only) — No private key needed. Use for queries.
+1. **WalletClient** (read/write) — Requires a private key. Use for creating, patching, deleting entities.
+2. **PublicClient** (read-only) — No private key needed. Use for queries and event watching.
 
 ```typescript
-import { createWalletClient, createPublicClient } from "@arkiv-network/sdk";
-import { braga } from "@arkiv-network/sdk/chains";
-import { http } from "viem";
-import { privateKeyToAccount } from "viem/accounts";
+import { createWalletClient, createPublicClient } from "@arkiv-network/sdk"
+import { cheesecake } from "@arkiv-network/sdk/chains"
+import { http } from "viem"
+import { privateKeyToAccount } from "viem/accounts"
 
-// Write operations — keep private key in env vars, never hardcode
+const rpcUrl = process.env.CHEESECAKE_RPC_URL
+// Register an API key at https://hub.arkiv.network/api-keys
+// and include it in the URL: https://rpc.cheesecake.db-chain.devnet.gobas.me/<key>
+
 const walletClient = createWalletClient({
-  chain: braga,
-  transport: http(),
+  chain: cheesecake,
+  transport: http(rpcUrl),
   account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
-});
+})
 
-// Read operations — safe for frontend/public use
 const publicClient = createPublicClient({
-  chain: braga,
-  transport: http(),
-});
+  chain: cheesecake,
+  transport: http(rpcUrl),
+})
 ```
 
-Braga is the current Arkiv testnet. If you are upgrading an existing Kaolin project, read `references/migration-guide.md` before editing code so you update chain imports, RPC URLs, wallet config, and seed data together.
+Cheesecake is the current Arkiv devnet. If you are upgrading from Braga, read `references/migration-guide.md` before editing code.
+
+## Wallet Actions
+
+The SDK exposes six core mutation methods:
+
+| Action | What it does |
+|--------|--------------|
+| `createEntity()` | Creates a new entity with a payload, content type, attributes, and an expiry |
+| `patchEntity()` | Sets or unsets individual attributes, or replaces the payload, leaving anything unnamed untouched |
+| `deleteEntity()` | Deletes an entity |
+| `extendEntity()` | Moves an entity's expiry later |
+| `changeOwnership()` | Transfers an entity to a new owner |
+| `executeBatch()` | Applies a combination of creates, patches, deletes, extensions, and ownership changes atomically in one transaction |
 
 ## CRUD Operations
 
 ### Create
 
 ```typescript
-import { jsonToPayload, ExpirationTime } from "@arkiv-network/sdk/utils";
+import { jsonToPayload, ExpirationTime } from "@arkiv-network/sdk"
+import { i32 } from "@arkiv-network/sdk/attr"
 
 const { entityKey, txHash } = await walletClient.createEntity({
   payload: jsonToPayload({ title: "My Note", content: "Hello Arkiv!" }),
   contentType: "application/json",
-  attributes: [
-    { key: "type", value: "note" },
-    { key: "id", value: crypto.randomUUID() },
-    { key: "created", value: Date.now() },
-  ],
-  expiresIn: ExpirationTime.fromHours(12),
-});
+  attributes: {
+    project: "myapp-acme-7x9k",
+    type: "note",
+    id: crypto.randomUUID(),
+    created: i32(Date.now()),
+  },
+  expires: ExpirationTime.fromHours(12),
+})
 ```
 
 ### Read / Query
 
-Start a query with `select()`, declaring which entity fields you want returned. Every field is opt-in — including `key` — and only the selected fields are fetched over the network, so ask for exactly what you'll use:
+Start a query with `select()`, declaring which entity fields you want returned. Every field is opt-in — including `key` — and only the selected fields are fetched over the network:
 
 ```typescript
-import { eq, gt } from "@arkiv-network/sdk/query";
+import { eq, gt } from "@arkiv-network/sdk/query"
+import { i32 } from "@arkiv-network/sdk/attr"
 
 const result = await publicClient
   .select({ key: true, payload: true, attributes: true })
-  .where(eq("type", "note"), gt("created", Date.now() - 86400000))
+  .where(eq("type", "note"), gt("created", i32(Date.now() - 86400000)))
   .limit(10)
-  .fetch();
+  .fetch()
 
-console.log("Found entities:", result.entities);
+console.log("Found entities:", result.entities)
 
-// Pagination — fetch the next page if one exists
 if (result.hasNextPage()) {
-  await result.next();
-  console.log("Next page:", result.entities);
+  await result.next()
 }
 
-// Get a specific entity by key
-const entity = await publicClient.getEntity(entityKey);
+const entity = await publicClient.getEntity(entityKey)
 ```
 
-Available fields: `key`, `owner`, `creator`, `contentType`, `payload`, `attributes`, `expiresAtBlock`, `createdAtBlock`, `lastModifiedAtBlock`, `transactionIndexInBlock`, `operationIndexInTransaction`. The result type is inferred from the selection — `entity.toJson()`/`entity.toText()` only exist when you select `payload`, and accessing an unselected field is a compile error.
+Available fields: `key`, `owner`, `creator`, `createdAt`, `updatedAt`, `expiresAt`, `creationFlags`, `contentType`, `payload`, `attributeSchema`, `attributes`.
 
-Pass the selection **inline**. A selection stored in a variable widens `true` to `boolean` and the result type can't be narrowed; if you must reuse one, annotate it `as const`. `select()` with no argument (or `"*"`) fetches every field — fine while prototyping, wasteful in production.
+Pass the selection **inline**. A selection stored in a variable widens `true` to `boolean` and the result type can't be narrowed; if you must reuse one, annotate it `as const`.
 
 `.where()` accepts conditions as varargs, an array, or chained calls — all combined with AND. For nested logic, combine predicates with `and()` / `or()` from `@arkiv-network/sdk/query`:
 
 ```typescript
-import { and, or, eq, gt } from "@arkiv-network/sdk/query";
+import { and, or, eq, gt } from "@arkiv-network/sdk/query"
+import { i32 } from "@arkiv-network/sdk/attr"
 
-// type = "note" AND (priority > 3 OR pinned = "true")
 await publicClient
   .select({ key: true, payload: true })
-  .where(eq("type", "note"), or(gt("priority", 3), eq("pinned", "true")))
-  .fetch();
+  .where(eq("type", "note"), or(gt("priority", i32(3)), eq("pinned", "true")))
+  .fetch()
 ```
 
-### Update
+### Patch
 
-`updateEntity` is a **full replace**, not a patch — see best practice 15 below before using it:
+`patchEntity` is a **partial update** — only fields named in `set`, `unset`, `payload`, or `contentType` are touched:
 
 ```typescript
-await walletClient.updateEntity({
-  entityKey: entityKey,
-  payload: jsonToPayload({ title: "Updated", content: "New content" }),
-  contentType: "application/json",
-  attributes: [
-    { key: "type", value: "note" },
-    { key: "updated", value: Date.now() },
-  ],
-  expiresIn: ExpirationTime.fromHours(24),
-});
+await walletClient.patchEntity({
+  entityKey,
+  set: { status: "done", updated: i32(Date.now()) },
+  unset: ["draft"],
+})
 ```
+
+Entity key, owner, creation flags, and expiry never change via patch. Use `extendEntity()` for expiry and `changeOwnership()` for ownership.
 
 ### Delete
 
 ```typescript
-await walletClient.deleteEntity({ entityKey });
+await walletClient.deleteEntity({ entityKey })
 ```
 
 ### Extend Expiration
 
 ```typescript
 await walletClient.extendEntity({
-  entityKey: entityKey,
-  expiresIn: ExpirationTime.fromHours(1), // always use the helper
-});
+  entityKey,
+  expires: ExpirationTime.fromHours(1),
+})
+```
+
+### Change Ownership
+
+```typescript
+await walletClient.changeOwnership({
+  entityKey,
+  newOwner: "0xNewOwnerAddress",
+})
 ```
 
 ## Best Practices
@@ -213,135 +241,151 @@ await walletClient.extendEntity({
 
 All entities in Arkiv are public and stored in a shared database. Every project **must** define a unique project attribute and include it on every entity. This is how you distinguish your app's data from everyone else's.
 
-Create a dedicated file (e.g., `lib/arkiv.ts` or `constants/arkiv.ts`) that exports this attribute:
+Create a dedicated file (e.g., `lib/arkiv.ts`) that exports the attribute name and value as separate constants:
 
 ```typescript
-/** All entities created by this app share this attribute for easy filtering. */
-export const PROJECT_ATTRIBUTE = {
-  key: "project",
-  value: "<GLOBALLY_UNIQUE_STRING_THAT_IDENTIFIES_THE_PROJECT>",
-} as const;
+/** Attribute name used to filter this project's entities. */
+export const PROJECT_ATTRIBUTE_NAME = "project" as const
 
-if (!PROJECT_ATTRIBUTE.value) {
+/** Globally unique value identifying this project. */
+export const PROJECT_ATTRIBUTE_VALUE = "myapp-acme-7x9k" as const
+
+if (!PROJECT_ATTRIBUTE_VALUE) {
   throw new Error(
-    "Please set the value of PROJECT_ATTRIBUTE to a unique string that identifies your project. This will help you filter and manage your entities on the Arkiv network.",
-  );
+    "Set PROJECT_ATTRIBUTE_VALUE to a unique string that identifies your project.",
+  )
 }
 ```
 
-When creating this file, come up with a globally unique value — for example, a combination of your project name, organization, and a short random suffix (e.g., `"myapp-acme-7x9k"`).
+When creating this file, come up with a globally unique value — for example, a combination of your project name, organization, and a short random suffix.
 
-Then include `PROJECT_ATTRIBUTE` in **every** create/update call and **every** query:
+Include the project attribute in **every** create/patch and **every** query:
 
 ```typescript
-// Creating — always include PROJECT_ATTRIBUTE
+import { PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE } from "@/lib/arkiv"
+
 const { entityKey, txHash } = await walletClient.createEntity({
   payload: jsonToPayload({ title, content }),
   contentType: "application/json",
-  attributes: [PROJECT_ATTRIBUTE, { key: "entityType", value: "post" }],
-  expiresIn: ExpirationTime.fromDays(30),
-});
+  attributes: {
+    [PROJECT_ATTRIBUTE_NAME]: PROJECT_ATTRIBUTE_VALUE,
+    entityType: "post",
+  },
+  expires: ExpirationTime.fromDays(30),
+})
 
-// Querying — always filter by PROJECT_ATTRIBUTE
 const result = await publicClient
   .select({ key: true, payload: true })
   .where(
-    eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value),
+    eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE),
     eq("entityType", "post"),
   )
   .limit(50)
-  .fetch();
+  .fetch()
 ```
 
 Without this, your queries will return data from other projects, and other projects will see yours. This is the single most important practice for any Arkiv project.
 
-### 2. Separate Read and Write Clients
+### 2. Register an RPC API Key
 
-Always use `createPublicClient` for queries. It prevents accidental writes, doesn't require a private key, and is safe for frontend/public use. Reserve `createWalletClient` for backend services that need to create/update/delete.
+Anonymous RPC access to Cheesecake is rate-limited. Register a project at `https://hub.arkiv.network/api-keys` for elevated rate limits (1,000,000 units/month). Pass the key as a URL path segment, `X-API-KEY` header, or `Authorization: Bearer` header:
 
-### 3. Design Attributes for Queryability
+```typescript
+const rpcUrl = `https://rpc.cheesecake.db-chain.devnet.gobas.me/${process.env.CHEESECAKE_API_KEY}`
+
+const publicClient = createPublicClient({
+  chain: cheesecake,
+  transport: http(rpcUrl),
+})
+```
+
+### 3. Separate Read and Write Clients
+
+Always use `createPublicClient` for queries. It prevents accidental writes, doesn't require a private key, and is safe for frontend/public use. Reserve `createWalletClient` for backend services that need to create/patch/delete.
+
+### 4. Design Attributes for Queryability
 
 Think about how you'll query data when you choose attributes. Attributes are your indexes — without the right ones, you'll be fetching too much data and filtering client-side.
 
 ```typescript
-// Good: attributes map to your query patterns
-attributes: [
-  { key: "type", value: "vote" }, // filter by entity type
-  { key: "proposalKey", value: proposalId }, // link related entities
-  { key: "voter", value: voterAddr }, // filter by user
-  { key: "choice", value: "yes" }, // filter by value
-  { key: "weight", value: 1 }, // numeric for aggregation
-];
+attributes: {
+  type: "vote",
+  proposalKey: proposalId,
+  voter: voterAddr,
+  choice: "yes",
+  weight: i32(1),
+}
 ```
 
-### 4. Use Batch Operations — and Never Parallelize Writes from One Wallet
+### 5. Use Batch Operations — and Never Parallelize Writes from One Wallet
 
-Every write is an on-chain transaction, and all transactions from one wallet must use strictly sequential nonces. The SDK does not manage nonces for you — two writes in flight at the same moment fetch the **same** nonce and collide: one gets rejected or silently replaces the other.
+Every write is an on-chain transaction, and all transactions from one wallet must use strictly sequential nonces. The SDK does not manage nonces for you — two writes in flight at the same moment fetch the **same** nonce and collide.
 
 ```typescript
 // Bad — sequential, slow and expensive
 for (const item of items) {
-  await walletClient.createEntity(item);
+  await walletClient.createEntity(item)
 }
 
 // Also bad — parallel writes from one wallet collide on the transaction nonce
-await Promise.all(items.map((item) => walletClient.createEntity(item)));
+await Promise.all(items.map((item) => walletClient.createEntity(item)))
 
 // Good — single batch operation, single transaction, one nonce
-await walletClient.mutateEntities({
+await walletClient.executeBatch({
   creates: items.map((item) => ({
     payload: jsonToPayload(item.data),
     contentType: "application/json",
     attributes: item.attributes,
-    expiresIn: ExpirationTime.fromHours(1),
+    expires: ExpirationTime.fromHours(1),
   })),
-});
+})
 ```
 
-`mutateEntities()` accepts `creates`, `updates`, `deletes`, `extensions`, and `ownershipChanges`, and you can mix them in one call. If separate concurrent transactions are unavoidable, create the account with viem's `nonceManager` (`privateKeyToAccount(key, { nonceManager })` from `viem/accounts`) so nonces are allocated locally — but note this only coordinates writes within a single process. Multiple processes writing with the same private key will still collide; give each writer its own wallet or route all writes through one process.
+`executeBatch()` accepts `creates`, `patches`, `deletes`, `extensions`, and `ownershipChanges`, and you can mix them in one call. If separate concurrent transactions are unavoidable, create the account with viem's `nonceManager` (`privateKeyToAccount(key, { nonceManager })` from `viem/accounts`) so nonces are allocated locally — but note this only coordinates writes within a single process.
 
-### 5. Write Specific Queries
+### 6. Write Specific Queries
 
 Broad queries return too much data and cost more. Always add multiple filter criteria:
 
 ```typescript
-// Bad — returns every note ever
-await publicClient.select({ key: true }).where(eq("type", "note")).fetch();
-
-// Good — narrows down to what you actually need
 await publicClient
   .select({ key: true })
   .where(
     eq("type", "note"),
-    gt("created", Date.now() - 86400000),
-    gt("priority", 3),
+    gt("created", i32(Date.now() - 86400000)),
+    gt("priority", i32(3)),
   )
-  .fetch();
+  .fetch()
 ```
 
-The same thinking applies to field selection: `select()` fetches only the fields you name, so ask for what you'll actually use — don't select everything out of habit.
+The same thinking applies to field selection: `select()` fetches only the fields you name, so ask for what you'll actually use.
 
-### 6. Right-Size Expiration
+### 7. Right-Size Expiration
 
-Match `expiresIn` to actual data lifetime. Session data gets 30 minutes, not 7 days. Cache gets 1 hour. Don't over-allocate — it costs more and pollutes queries with stale data before cleanup.
+Match `expires` to actual data lifetime. Session data gets 30 minutes, not 7 days. Cache gets 1 hour. Don't over-allocate — it costs more and pollutes queries with stale data before cleanup.
 
-### 7. Never Expose Private Keys
+### 8. Never Expose Private Keys
 
 ```typescript
-// Always load from environment
-const privateKey = process.env.PRIVATE_KEY;
-
-// Never hardcode
-const privateKey = "0x1234..."; // DANGEROUS
+const privateKey = process.env.PRIVATE_KEY
+// Never hardcode: const privateKey = "0x1234..." // DANGEROUS
 ```
 
-### 8. Validate Input Before Storing
+### 9. Use Typed Attributes for Typed Data
 
-Check length and content before creating entities. Arkiv stores what you give it — garbage in, garbage out.
+Use the typed helpers from `@arkiv-network/sdk/attr` for attributes you'll filter or sort by:
 
-### 9. Use Numeric Types for Numeric Data
+```typescript
+import { i32, dec, u64 } from "@arkiv-network/sdk/attr"
 
-If you'll filter or sort by a value, store it as a number attribute. String attributes only support equality checks. Remember that numeric attribute values must be **integers** — scale floats to a fixed precision (e.g. `19.99` → `{ key: 'priceCents', value: 1999 }`) so range queries keep working.
+attributes: {
+  priceCents: i32(1999),       // integer range queries
+  rating: dec("4.5"),            // genuine decimal
+  blockHeight: u64(1_200_000n),  // large unsigned integer
+}
+```
+
+String attributes only support equality and prefix matching. Numeric attributes support all comparison operators.
 
 ### 10. Model Related Data with Shared Attributes
 
@@ -349,132 +393,101 @@ Link entities together using a shared attribute key (like `proposalKey` in a vot
 
 ```typescript
 // Proposal entity
-attributes: [{ key: "type", value: "proposal" }];
+attributes: { type: "proposal" }
 
 // Vote entities reference the proposal
-attributes: [
-  { key: "type", value: "vote" },
-  { key: "proposalKey", value: proposalEntityKey },
-];
+attributes: {
+  type: "vote",
+  proposalKey: proposalEntityKey,
+}
 
 // Query all votes for a proposal
 await publicClient
   .select({ key: true, payload: true })
   .where(eq("type", "vote"), eq("proposalKey", proposalEntityKey))
-  .fetch();
+  .fetch()
 ```
 
 ### 11. Understand $owner vs $creator
 
 Every Arkiv entity has two special metadata fields:
 
-- **$owner** — The wallet address that currently owns the entity. The owner has permission to update, delete, and extend the entity. **Ownership can be transferred**, so the owner may change over an entity's lifetime.
+- **$owner** — The wallet address that currently owns the entity. The owner has permission to patch, delete, and extend the entity. **Ownership can be transferred**, so the owner may change over an entity's lifetime.
 - **$creator** — The wallet address that originally created the entity. This is **set at creation time and is immutable** — it can never change. Being the creator does not grant any special privileges (only the owner can modify/delete).
 
 Query these with `.ownedBy()` and `.createdBy()`, or include them in results by selecting the `owner` / `creator` fields:
 
 ```typescript
-// Filter by current owner
 const owned = await publicClient
   .select({ key: true, owner: true, payload: true })
-  .where(eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value))
+  .where(eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE))
   .ownedBy("0xOwnerAddress")
-  .fetch();
+  .fetch()
 
-// Filter by original creator (immutable, tamper-proof)
 const created = await publicClient
   .select({ key: true, creator: true, payload: true })
-  .where(eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value))
+  .where(eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE))
   .createdBy("0xCreatorAddress")
-  .fetch();
+  .fetch()
 ```
 
 **When to use which:**
 
-- Use **$creator** (`createdBy`) when you need a tamper-proof guarantee of who originally wrote the data (e.g., verifying data came from your trusted backend). Since it's immutable, it cannot be spoofed after creation.
-- Use **$owner** (`ownedBy`) when you need to know who currently controls the entity (e.g., checking who can modify it). Be aware that ownership can change.
+- Use **$creator** (`createdBy`) when you need a tamper-proof guarantee of who originally wrote the data. Since it's immutable, it cannot be spoofed after creation.
+- Use **$owner** (`ownedBy`) when you need to know who currently controls the entity. Be aware that ownership can change.
 
 ### 12. Filter by Creator Wallet for Trusted Data
 
-When your app has a backend that publishes data to Arkiv and a frontend that reads it, filtering by `PROJECT_ATTRIBUTE` alone is **not enough**. A malicious actor can create entities with your project attribute to inject fake data into your dashboard.
+When your app has a backend that publishes data to Arkiv and a frontend that reads it, filtering by `PROJECT_ATTRIBUTE` alone is **not enough**. A malicious actor can create entities with your project attribute to inject fake data.
 
-The solution: combine `PROJECT_ATTRIBUTE` filtering with `.createdBy()` to only accept entities created by your trusted backend wallet:
-
-```typescript
-// lib/arkiv.ts — export your trusted backend wallet address
-export const PROJECT_ATTRIBUTE = {
-  key: "project",
-  value: "myapp-acme-7x9k",
-} as const;
-
-/** The wallet address of the backend that publishes trusted data. */
-export const CREATOR_WALLET_ADDRESS = "0xYourBackendWalletAddress";
-```
+Combine `PROJECT_ATTRIBUTE` filtering with `.createdBy()` to only accept entities created by your trusted backend wallet:
 
 ```typescript
-// Reading trusted data only
-import { PROJECT_ATTRIBUTE, CREATOR_WALLET_ADDRESS } from "@/lib/arkiv";
+export const CREATOR_WALLET_ADDRESS = "0xYourBackendWalletAddress"
 
 const trustedPosts = await publicClient
   .select({ key: true, payload: true })
   .where(
-    eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value),
+    eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE),
     eq("entityType", "post"),
   )
   .createdBy(CREATOR_WALLET_ADDRESS)
-  .fetch();
+  .fetch()
 ```
 
-This works because `$creator` is immutable — no one can create an entity and fake the creator address. Even if someone creates an entity with your project attribute, it won't pass the `.createdBy()` filter unless it was actually created by your whitelisted wallet.
-
-**Use this pattern whenever:**
-
-- Your backend publishes data that a frontend/dashboard reads
-- You need to trust the source of entities
-- You're building any system where data integrity matters
+This works because `$creator` is immutable — no one can create an entity and fake the creator address.
 
 ### 13. Handle Errors Gracefully
 
-The Arkiv SDK does not retry on failure — all methods throw on error. Write operations (create, update, delete, extend) can fail for several reasons: the user rejects the transaction in MetaMask, the wallet has insufficient gas, the RPC endpoint is unreachable, or the entity has already expired. Wrap write operations in try/catch and handle each failure mode appropriately:
+The Arkiv SDK does not retry on failure — all methods throw on error. Write operations can fail for several reasons: the user rejects the transaction in MetaMask, the wallet has insufficient gas, the RPC endpoint is unreachable, or the entity has already expired. Wrap write operations in try/catch:
 
 ```typescript
-try {
-  const { entityKey, txHash } = await walletClient.createEntity({
-    payload: jsonToPayload({ title: "My Post" }),
-    contentType: "application/json",
-    attributes: [PROJECT_ATTRIBUTE, { key: "entityType", value: "post" }],
-    expiresIn: ExpirationTime.fromHours(12),
-  });
-} catch (error) {
-  // Common failures:
-  // - Invalid input (InvalidAttributeError, InvalidExpirationError)
-  // - User rejected the transaction (MetaMask popup dismissed)
-  // - Insufficient funds / gas
-  // - Network error (RPC unreachable)
-  // - Entity already expired (for update/extend)
-  console.error("Transaction failed:", error);
-}
-```
-
-Since 0.7.0 the SDK validates inputs client-side and throws typed errors before anything hits the network. They're exported from the package root, so you can handle them specifically:
-
-```typescript
-import { InvalidAttributeError, InvalidExpirationError } from "@arkiv-network/sdk";
+import {
+  InvalidValueError,
+  InvalidExpiryError,
+  EmptyPatchError,
+  ConflictingMutationError,
+  NoEntityFoundError,
+} from "@arkiv-network/sdk"
 
 try {
-  await walletClient.createEntity({ /* ... */ });
+  await walletClient.createEntity({ /* ... */ })
 } catch (error) {
-  if (error instanceof InvalidAttributeError) {
-    // a numeric attribute value was not an integer
-  } else if (error instanceof InvalidExpirationError) {
-    // expiresIn was not a positive multiple of the 2s block time
+  if (error instanceof InvalidValueError) {
+    // a value did not match its declared type (e.g. bare float)
+  } else if (error instanceof InvalidExpiryError) {
+    // invalid expiry configuration
+  } else if (error instanceof EmptyPatchError) {
+    // patchEntity called with no changes
+  } else if (error instanceof ConflictingMutationError) {
+    // same attribute in both set and unset
   } else {
-    throw error;
+    throw error
   }
 }
 ```
 
-Read operations (`select().fetch()`, `getEntity()`) can also throw on network errors. If your app needs retries, implement them yourself — the SDK won't do it for you.
+Read operations can also throw on network errors. If your app needs retries, implement them yourself — the SDK won't do it for you.
 
 ### 14. Validate Entity Data and Model Relationships
 
@@ -485,100 +498,119 @@ Two important advanced patterns for production Arkiv apps:
 
 For full examples and code for both patterns, read `references/advanced-patterns.md`.
 
-### 15. Remember That updateEntity Is a Full Replace
+### 15. Remember That patchEntity Is a Partial Update
 
-`updateEntity` is a full replace, not a patch: the attribute set becomes exactly the list you provide, and the payload, content type, and expiration are all overwritten. Any attribute you omit is silently removed. To change only some fields, read the entity first and re-send the complete state with your changes applied:
+`patchEntity` only touches what you name — attributes in `set` are added/updated, names in `unset` are removed, and anything not mentioned stays as-is. Entity key, owner, creation flags, and expiry never change via patch:
 
 ```typescript
-// Bad — wipes every attribute except "status", replaces the payload
-await walletClient.updateEntity({
+// Good — only changes status, leaves everything else untouched
+await walletClient.patchEntity({
   entityKey,
-  payload: jsonToPayload({}),
-  contentType: "application/json",
-  attributes: [{ key: "status", value: "done" }],
-  expiresIn: ExpirationTime.fromDays(7),
-});
+  set: { status: "done" },
+  unset: ["draft"],
+})
 
-// Good — read, modify, write back the full entity
-const entity = await publicClient.getEntity(entityKey);
+// Bad — throws EmptyPatchError
+await walletClient.patchEntity({ entityKey })
 
-await walletClient.updateEntity({
+// Bad — throws ConflictingMutationError
+await walletClient.patchEntity({
   entityKey,
-  payload: entity.payload,
-  contentType: entity.contentType,
-  attributes: [
-    ...entity.attributes.filter((attr) => attr.key !== "status"),
-    { key: "status", value: "done" },
-  ],
-  expiresIn: ExpirationTime.fromDays(7),
-});
+  set: { status: "done" },
+  unset: ["status"],
+})
 ```
 
-### 16. Sort Client-Side — orderBy Is Deprecated
+To replace the payload without touching attributes:
 
-The network always returns matching entities **newest first**; server-side ordering by anything else is not supported. The query builder's `orderBy()` and the `asc()` / `desc()` helpers are deprecated no-ops since SDK 0.7.0 — remove them from existing code rather than trusting them. To sort by an attribute, fetch the entities and sort in JavaScript:
+```typescript
+await walletClient.patchEntity({
+  entityKey,
+  payload: jsonToPayload({ title: "Updated", content: "New content" }),
+  contentType: "application/json",
+})
+```
+
+### 16. Sort Client-Side — Server Ordering Is Not Supported
+
+The network always returns matching entities **newest first**; server-side ordering by anything else is not supported. `orderBy()`, `asc()`, and `desc()` were removed in SDK 0.8. To sort by an attribute, fetch the entities and sort in JavaScript:
 
 ```typescript
 const { entities } = await publicClient
   .select({ key: true, payload: true, attributes: true })
   .where(eq("type", "note"))
-  .fetch();
+  .fetch()
 
 const priorityOf = (entity: (typeof entities)[number]) =>
-  Number(entity.attributes.find((attr) => attr.key === "priority")?.value ?? 0);
+  Number(entity.attributes.priority?.value ?? 0)
 
-// Highest priority first
-entities.sort((a, b) => priorityOf(b) - priorityOf(a));
+entities.sort((a, b) => priorityOf(b) - priorityOf(a))
 ```
 
 **Caution:** `.limit(n)` caps results **before** your sort — it gives you the n *newest* matches, not the top n by your attribute. To get a true top n, fetch all matching entities (paginating if needed), then sort and slice.
 
-## Upgrading to SDK 0.7.0
+## Upgrading to SDK 0.8.0
 
-When a project upgrades `@arkiv-network/sdk` from 0.6.x to 0.7.0+, apply all of these together — they ship in one release:
+When a project upgrades `@arkiv-network/sdk` from 0.7.x to 0.8.0-dev.3+, apply all of these together:
 
-1. **Install viem** — it's now a peer dependency: `npm install @arkiv-network/sdk viem`.
-2. **Fix imports** — the SDK no longer re-exports viem's internals. Move `http`, `custom`, `Hex` imports to `viem` and `privateKeyToAccount` to `viem/accounts`. Imports from `@arkiv-network/sdk/accounts` are gone.
-3. **Migrate queries** — replace `buildQuery()` + `.withPayload(true)`/`.withAttributes(true)`/`.withMetadata(true)` with `select({...})`, naming the fields you need (`payload`, `attributes`, `owner`, `creator`, `key`, ...). Every field is opt-in, including `key`.
-4. **Remove `orderBy()`/`asc()`/`desc()`** — deprecated no-ops. Sort fetched entities in JavaScript instead (see best practice 16).
-5. **Audit inputs against the new client-side validation** — non-integer numeric attribute values now throw `InvalidAttributeError`, and `expiresIn` values that aren't a positive multiple of 2 throw `InvalidExpirationError`. Code that previously "worked" with floats or odd expirations will start throwing.
+1. **Install the dev release:** `npm install @arkiv-network/sdk@dev viem`.
+2. **Swap chain:** `braga` → `cheesecake` in all imports and client setup.
+3. **Fix imports:** import `ExpirationTime`, `jsonToPayload`, `stringToPayload` from `@arkiv-network/sdk` root (not `/utils`).
+4. **Attributes array → object:** `{ key: "type", value: "note" }` → `{ type: "note" }`.
+5. **`expiresIn` → `expires`:** rename the parameter on create/extend/batch.
+6. **`updateEntity` → `patchEntity`:** partial updates with `set`/`unset` instead of full replace.
+7. **`mutateEntities` → `executeBatch`:** rename and use `patches` instead of `updates`.
+8. **`subscribeEntityEvents` → `watchEntityEvents`:** sync, returns unwatch function directly.
+9. **Error renames:** `InvalidAttributeError` → `InvalidValueError`, `InvalidExpirationError` → `InvalidExpiryError`.
+10. **Remove `orderBy()`/`asc()`/`desc()`:** sort client-side.
+11. **Remove `payloadToString`:** use `entity.toText()` / `entity.toJson()`.
+12. **Use typed attribute helpers:** import from `@arkiv-network/sdk/attr` for non-default types.
 
-## Migration from Kaolin to Braga
+For the full migration checklist including network constants, read `references/migration-guide.md`.
 
-When a user wants to upgrade an existing Arkiv project, treat it as a migration instead of a generic refactor. The SDK API is unchanged; the main work is swapping the target chain, updating wallet/network config, renaming Kaolin-specific env vars, and recreating testnet data that lived on Kaolin.
+## Migration from Braga to Cheesecake
+
+Braga was retired on 12 August 2026. When a user wants to upgrade an existing Arkiv project, treat it as a migration instead of a generic refactor. The SDK API has breaking changes from 0.7 to 0.8, and the main work is swapping the target chain, updating wallet/network config, renaming Braga-specific env vars, and recreating testnet data.
 
 Follow this sequence:
 
 1. Read `references/migration-guide.md` before making edits.
-2. Check the installed `@arkiv-network/sdk` version first. The `braga` chain export is only available in `0.6.5` or higher. If the upgrade lands on `0.7.0+`, also apply the "Upgrading to SDK 0.7.0" checklist above (viem peer dependency, import moves, `select()` migration).
-3. Replace `kaolin` chain imports/usages with `braga`.
-4. Update RPC URLs, WebSocket URLs, chain IDs, explorer links, faucet links, and wallet `nativeCurrency` from ETH to GLM.
-5. Rename env vars and config keys so `KAOLIN_*` names do not remain in active codepaths.
-6. Re-seed or recreate any entities the app expects on startup, because Kaolin state does not migrate to Braga.
+2. Install `@arkiv-network/sdk@dev` and apply the "Upgrading to SDK 0.8.0" checklist above.
+3. Replace `braga` chain imports/usages with `cheesecake`.
+4. Update RPC URLs, WebSocket URLs, chain IDs, explorer links, faucet links, and wallet `nativeCurrency` (symbol `GLM`).
+5. Register an RPC API key at `https://hub.arkiv.network/api-keys`.
+6. Rename env vars and config keys so `BRAGA_*` names do not remain in active codepaths.
+7. Re-seed or recreate any entities the app expects on startup, because Braga state does not migrate to Cheesecake.
 
-Keep Kaolin only as legacy context during migration work. For new code, examples, and setup instructions, default to Braga.
+Keep Braga only as legacy context during migration work. For new code, examples, and setup instructions, default to Cheesecake.
 
 ## Reference Files
 
 The `references/` directory contains detailed documentation for specific topics. Read these when you need deeper information:
 
-- **`references/sdk-reference.md`** — Full SDK API surface: all WalletClient/PublicClient methods, the `select()` query builder API, validation rules, nonce management, ExpirationTime helpers, payload utilities, MetaMask browser usage, and CDN imports.
-- **`references/integration-patterns.md`** — Three integration scenarios: backend read/write (Next.js/Express), client-side reading (TanStack Query hooks), and client-side writing (MetaMask and wagmi/RainbowKit).
-- **`references/api-reference.md`** — Raw JSON-RPC 2.0 API: `arkiv_query` syntax, query operators, synthetic attributes (`$owner`, `$creator`, `$key`), pagination with cursors, and utility methods.
+- **`references/sdk-reference.md`** — Full SDK API surface: all WalletClient/PublicClient methods, the `select()` query builder API, typed attributes, validation rules, nonce management, ExpirationTime helpers, payload utilities, `watchEntityEvents`, MetaMask browser usage, and CDN imports.
+- **`references/integration-patterns.md`** — Four integration scenarios: backend read/write (Next.js/Express), client-side reading (TanStack Query hooks), client-side writing (MetaMask and wagmi/RainbowKit), and live events with cache invalidation.
+- **`references/api-reference.md`** — Raw JSON-RPC 2.0 API: `arkiv_query` syntax, typed literals, query operators, synthetic attributes, pagination with cursors, and utility methods.
 - **`references/advanced-patterns.md`** — Advanced data modeling: schema validation with zod/valibot, and modeling lists with relationship entities.
-- **`references/migration-guide.md`** — Step-by-step Kaolin to Braga migration checklist: chain swaps, env/config updates, wallet settings, faucet, bridge changes, and reseeding testnet data.
+- **`references/migration-guide.md`** — Step-by-step Braga to Cheesecake migration checklist: chain swaps, SDK 0.7→0.8 API changes, env/config updates, faucet, and reseeding testnet data.
 
 ## Testnet Resources
 
-| Resource | URL                                            |
-| -------- | ---------------------------------------------- |
-| Chain ID | `60138453102`                                  |
-| HTTP RPC | `https://braga.hoodi.arkiv.network/rpc`        |
-| Faucet   | `https://braga.hoodi.arkiv.network/faucet/`    |
-| Explorer | `https://explorer.braga.hoodi.arkiv.network/`  |
+| Resource | URL |
+| -------- | --- |
+| Chain ID | `7733102` / `0x75ff6e` |
+| HTTP RPC | `https://rpc.cheesecake.db-chain.devnet.gobas.me` |
+| WebSocket RPC | `wss://rpc.cheesecake.db-chain.devnet.gobas.me` |
+| Block explorer | `https://indexer.cheesecake.db-chain.devnet.gobas.me` |
+| Faucet | `https://hub.arkiv.network/faucet` (0.1 GLM, 24h cooldown, wallet + SIWE) |
+| API keys | `https://hub.arkiv.network/api-keys` |
 
 ## Troubleshooting
 
-- **"Invalid sender"** — Your RPC URL may point to the wrong network. Verify it matches Braga.
-- **"Insufficient funds"** — Get test GLM from the Braga faucet. Writes require gas.
+- **"Invalid sender"** — Your RPC URL may point to the wrong network. Verify it matches Cheesecake.
+- **"Insufficient funds"** — Get test GLM from the [Cheesecake faucet](https://hub.arkiv.network/faucet). Writes require gas.
 - **Queries return empty** — Check that attributes match exactly (case-sensitive). Verify entities haven't expired.
+- **`InvalidValueError` on a number** — Bare floats are rejected. Use `dec("19.99")` for decimals or `i32(1999)` for scaled integers.
+- **`NoEntityFoundError`** — The entity does not exist or has expired. Expiration fires no event in 0.8 — poll or query by `$expiresAt`.
+- **RPC rate limited** — Register an API key at `https://hub.arkiv.network/api-keys` and pass it in the RPC URL or as a header.
+- **Query parse error on `ne()`/`exists()`/`hasType()`** — These operators are exported by the SDK but not implemented on the node. Use `not(eq(...))` instead.

--- a/skills/arkiv-best-practices/SKILL.md
+++ b/skills/arkiv-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arkiv-best-practices
-description: Best practices, patterns, and practical examples for building applications with Arkiv — a decentralized Ethereum database with queryable, time-scoped storage. Use this skill whenever the user is working with Arkiv SDK, the @arkiv-network/sdk package, Arkiv entities, Arkiv queries, the select() query API, Arkiv attributes, typed attributes, dec(), Expiry/expiration, the Cheesecake devnet, patchEntity, executeBatch, watchEntityEvents, changeOwnership, or building any application that stores, queries, or manages data on the Arkiv network. Also use when the user mentions decentralized data storage on Ethereum, blockchain database, Web3 data storage, on-chain data, entity CRUD operations with expiration, arkiv_query, migrating an Arkiv project from Braga to Cheesecake, or upgrading an Arkiv project to SDK 0.8.
+description: Best practices, patterns, and practical examples for building applications with Arkiv — a decentralized Ethereum database with queryable, time-scoped storage. Use this skill whenever the user is working with Arkiv SDK, the @arkiv-network/sdk package, Arkiv entities, Arkiv queries, the select() query API, Arkiv attributes, typed attributes, dec(), Expiry/expiration, the Tiramisu testnet, patchEntity, executeBatch, watchEntityEvents, changeOwnership, or building any application that stores, queries, or manages data on the Arkiv network. Also use when the user mentions decentralized data storage on Ethereum, blockchain database, Web3 data storage, on-chain data, entity CRUD operations with expiration, arkiv_query, migrating an Arkiv project from Braga to Tiramisu, or upgrading an Arkiv project to SDK 0.8.
 ---
 
 # Arkiv Best Practices & Practical Examples
@@ -15,7 +15,7 @@ Arkiv is **designed as three layers**:
 2. **Arkiv Coordination Layer** — Data management, registry, cross-chain sync.
 3. **Specialized DB-Chains** — High-performance CRUD via JSON-RPC, indexed queries, programmable expiration.
 
-Nothing in the current source repos confirms the coordination layer or mainnet settlement is live on Cheesecake — treat the devnet as the active layer for now.
+Nothing in the current source repos confirms the coordination layer or mainnet settlement is live on Tiramisu — treat the testnet as the active layer for now.
 
 ## Core Concepts
 
@@ -102,27 +102,27 @@ Two client types exist:
 
 ```typescript
 import { createWalletClient, createPublicClient } from "@arkiv-network/sdk"
-import { cheesecake } from "@arkiv-network/sdk/chains"
+import { tiramisu } from "@arkiv-network/sdk/chains"
 import { http } from "viem"
 import { privateKeyToAccount } from "viem/accounts"
 
-const rpcUrl = process.env.CHEESECAKE_RPC_URL
+const rpcUrl = process.env.TIRAMISU_RPC_URL
 // Register an API key at https://hub.arkiv.network/api-keys
-// and include it in the URL: https://rpc.cheesecake.db-chain.devnet.gobas.me/<key>
+// and include it in the URL: https://rpc.tiramisu.db-chain.testnet.arkiv.network/<key>
 
 const walletClient = createWalletClient({
-  chain: cheesecake,
+  chain: tiramisu,
   transport: http(rpcUrl),
   account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
 })
 
 const publicClient = createPublicClient({
-  chain: cheesecake,
+  chain: tiramisu,
   transport: http(rpcUrl),
 })
 ```
 
-Cheesecake is the current Arkiv devnet. If you are upgrading from Braga, read `references/migration-guide.md` before editing code.
+Tiramisu is the current Arkiv testnet. If you are upgrading from Braga, read `references/migration-guide.md` before editing code.
 
 ## Wallet Actions
 
@@ -288,13 +288,13 @@ Without this, your queries will return data from other projects, and other proje
 
 ### 2. Register an RPC API Key
 
-Anonymous RPC access to Cheesecake is rate-limited. Register a project at `https://hub.arkiv.network/api-keys` for elevated rate limits (1,000,000 units/month). Pass the key as a URL path segment, `X-API-KEY` header, or `Authorization: Bearer` header:
+Anonymous RPC access to Tiramisu is rate-limited. Register a project at `https://hub.arkiv.network/api-keys` for elevated rate limits (1,000,000 units/month). Pass the key as a URL path segment, `X-API-KEY` header, or `Authorization: Bearer` header:
 
 ```typescript
-const rpcUrl = `https://rpc.cheesecake.db-chain.devnet.gobas.me/${process.env.CHEESECAKE_API_KEY}`
+const rpcUrl = `https://rpc.tiramisu.db-chain.testnet.arkiv.network/${process.env.TIRAMISU_API_KEY}`
 
 const publicClient = createPublicClient({
-  chain: cheesecake,
+  chain: tiramisu,
   transport: http(rpcUrl),
 })
 ```
@@ -554,7 +554,7 @@ entities.sort((a, b) => priorityOf(b) - priorityOf(a))
 When a project upgrades `@arkiv-network/sdk` from 0.7.x to 0.8.0-dev.3+, apply all of these together:
 
 1. **Install the dev release:** `npm install @arkiv-network/sdk@dev viem`.
-2. **Swap chain:** `braga` → `cheesecake` in all imports and client setup.
+2. **Swap chain:** `braga` → `tiramisu` in all imports and client setup.
 3. **Fix imports:** import `ExpirationTime`, `jsonToPayload`, `stringToPayload` from `@arkiv-network/sdk` root (not `/utils`).
 4. **Attributes array → object:** `{ key: "type", value: "note" }` → `{ type: "note" }`.
 5. **`expiresIn` → `expires`:** rename the parameter on create/extend/batch.
@@ -568,7 +568,7 @@ When a project upgrades `@arkiv-network/sdk` from 0.7.x to 0.8.0-dev.3+, apply a
 
 For the full migration checklist including network constants, read `references/migration-guide.md`.
 
-## Migration from Braga to Cheesecake
+## Migration from Braga to Tiramisu
 
 Braga was retired on 12 August 2026. When a user wants to upgrade an existing Arkiv project, treat it as a migration instead of a generic refactor. The SDK API has breaking changes from 0.7 to 0.8, and the main work is swapping the target chain, updating wallet/network config, renaming Braga-specific env vars, and recreating testnet data.
 
@@ -576,13 +576,13 @@ Follow this sequence:
 
 1. Read `references/migration-guide.md` before making edits.
 2. Install `@arkiv-network/sdk@dev` and apply the "Upgrading to SDK 0.8.0" checklist above.
-3. Replace `braga` chain imports/usages with `cheesecake`.
+3. Replace `braga` chain imports/usages with `tiramisu`.
 4. Update RPC URLs, WebSocket URLs, chain IDs, explorer links, faucet links, and wallet `nativeCurrency` (symbol `GLM`).
 5. Register an RPC API key at `https://hub.arkiv.network/api-keys`.
 6. Rename env vars and config keys so `BRAGA_*` names do not remain in active codepaths.
-7. Re-seed or recreate any entities the app expects on startup, because Braga state does not migrate to Cheesecake.
+7. Re-seed or recreate any entities the app expects on startup, because Braga state does not migrate to Tiramisu.
 
-Keep Braga only as legacy context during migration work. For new code, examples, and setup instructions, default to Cheesecake.
+Keep Braga only as legacy context during migration work. For new code, examples, and setup instructions, default to Tiramisu.
 
 ## Reference Files
 
@@ -592,23 +592,23 @@ The `references/` directory contains detailed documentation for specific topics.
 - **`references/integration-patterns.md`** — Four integration scenarios: backend read/write (Next.js/Express), client-side reading (TanStack Query hooks), client-side writing (MetaMask and wagmi/RainbowKit), and live events with cache invalidation.
 - **`references/api-reference.md`** — Raw JSON-RPC 2.0 API: `arkiv_query` syntax, typed literals, query operators, synthetic attributes, pagination with cursors, and utility methods.
 - **`references/advanced-patterns.md`** — Advanced data modeling: schema validation with zod/valibot, and modeling lists with relationship entities.
-- **`references/migration-guide.md`** — Step-by-step Braga to Cheesecake migration checklist: chain swaps, SDK 0.7→0.8 API changes, env/config updates, faucet, and reseeding testnet data.
+- **`references/migration-guide.md`** — Step-by-step Braga to Tiramisu migration checklist: chain swaps, SDK 0.7→0.8 API changes, env/config updates, faucet, and reseeding testnet data.
 
 ## Testnet Resources
 
 | Resource | URL |
 | -------- | --- |
-| Chain ID | `7733102` / `0x75ff6e` |
-| HTTP RPC | `https://rpc.cheesecake.db-chain.devnet.gobas.me` |
-| WebSocket RPC | `wss://rpc.cheesecake.db-chain.devnet.gobas.me` |
-| Block explorer | `https://indexer.cheesecake.db-chain.devnet.gobas.me` |
+| Chain ID | `7738577` / `0x7614d1` |
+| HTTP RPC | `https://rpc.tiramisu.db-chain.testnet.arkiv.network` |
+| WebSocket RPC | `wss://rpc.tiramisu.db-chain.testnet.arkiv.network` |
+| Block explorer | `https://indexer.tiramisu.db-chain.testnet.arkiv.network` |
 | Faucet | `https://hub.arkiv.network/faucet` (0.1 GLM, 24h cooldown, wallet + SIWE) |
 | API keys | `https://hub.arkiv.network/api-keys` |
 
 ## Troubleshooting
 
-- **"Invalid sender"** — Your RPC URL may point to the wrong network. Verify it matches Cheesecake.
-- **"Insufficient funds"** — Get test GLM from the [Cheesecake faucet](https://hub.arkiv.network/faucet). Writes require gas.
+- **"Invalid sender"** — Your RPC URL may point to the wrong network. Verify it matches Tiramisu.
+- **"Insufficient funds"** — Get test GLM from the [Tiramisu faucet](https://hub.arkiv.network/faucet). Writes require gas.
 - **Queries return empty** — Check that attributes match exactly (case-sensitive). Verify entities haven't expired.
 - **`InvalidValueError` on a number** — Bare floats are rejected. Use `dec("19.99")` for decimals or `i32(1999)` for scaled integers.
 - **`NoEntityFoundError`** — The entity does not exist or has expired. Expiration fires no event in 0.8 — poll or query by `$expiresAt`.

--- a/skills/arkiv-best-practices/references/advanced-patterns.md
+++ b/skills/arkiv-best-practices/references/advanced-patterns.md
@@ -1,11 +1,13 @@
 # Advanced Data Modeling Patterns
 
-Patterns for handling type safety and complex relationships in Arkiv.
+Patterns for handling type safety and complex relationships in Arkiv. All examples target `@arkiv-network/sdk@0.8.0-dev.3`.
 
 ## Table of Contents
 
-1. [Validate Entity Data with a Schema Library](#validate-entity-data-with-a-schema-library)
-2. [Model Lists with Relationship Entities](#model-lists-with-relationship-entities)
+- [Advanced Data Modeling Patterns](#advanced-data-modeling-patterns)
+  - [Table of Contents](#table-of-contents)
+  - [Validate Entity Data with a Schema Library](#validate-entity-data-with-a-schema-library)
+  - [Model Lists with Relationship Entities](#model-lists-with-relationship-entities)
 
 ---
 
@@ -24,13 +26,12 @@ const PostSchema = z.object({
 
 type Post = z.infer<typeof PostSchema>;
 
-// Safe parsing — never trust raw entity data
-function parsePost(entity: any): Post {
-  const raw = entity.toJson();
-  const result = PostSchema.safeParse(raw);
+function parsePost(entity: { toJson(): unknown }): Post {
+  const raw = entity.toJson()
+  const result = PostSchema.safeParse(raw)
   if (!result.success) {
-    console.error("Invalid entity data:", result.error.flatten());
-    throw new Error("Entity data does not match expected schema");
+    console.error("Invalid entity data:", result.error.flatten())
+    throw new Error("Entity data does not match expected schema")
   }
   return result.data;
 }
@@ -39,20 +40,20 @@ function parsePost(entity: any): Post {
 const result = await publicClient
   .select({ key: true, payload: true })
   .where(
-    eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value),
+    eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE),
     eq("entityType", "post"),
   )
   .fetch();
 
 const posts: Post[] = result.entities
-  .map((e) => {
+  .map((entity) => {
     try {
-      return parsePost(e);
+      return parsePost(entity);
     } catch {
       return null;
     }
   })
-  .filter((p): p is Post => p !== null);
+  .filter((post): post is Post => post !== null);
 ```
 
 This protects against:
@@ -68,17 +69,17 @@ This protects against:
 Arkiv attributes are flat key-value pairs — there is no native array type. A common mistake is trying to encode lists into attributes:
 
 ```typescript
-// BAD — indexed attributes. Can't query "all profiles with skill frontend"
-attributes: [
-  { key: "skills_0", value: "frontend" },
-  { key: "skills_1", value: "backend" },
-  { key: "skills_2", value: "devops" },
-]
+// BAD — indexed attribute keys. Can't query "all profiles with skill frontend"
+attributes: {
+  skills_0: "frontend",
+  skills_1: "backend",
+  skills_2: "devops",
+}
 
 // BAD — comma-separated string. Can't query individual skills
-attributes: [
-  { key: "skills", value: "frontend, backend, devops" },
-]
+attributes: {
+  skills: "frontend, backend, devops",
+}
 ```
 
 Both approaches break querying. You can't efficiently find "all profiles that have the `frontend` skill" without fetching everything and filtering client-side.
@@ -86,31 +87,33 @@ Both approaches break querying. You can't efficiently find "all profiles that ha
 **The correct pattern:** Create separate **relationship entities** that link the parent entity to each value. This is the relational model — one entity per relationship:
 
 ```typescript
+import { jsonToPayload, ExpirationTime } from "@arkiv-network/sdk"
+
 // 1. Create the profile entity
 const { entityKey: profileKey } = await walletClient.createEntity({
   payload: jsonToPayload({ name: "Alice", bio: "Full-stack dev" }),
   contentType: "application/json",
-  attributes: [
-    PROJECT_ATTRIBUTE,
-    { key: "entityType", value: "profile" },
-    { key: "profileId", value: "alice-123" },
-  ],
-  expiresIn: ExpirationTime.fromDays(30),
-});
+  attributes: {
+    [PROJECT_ATTRIBUTE_NAME]: PROJECT_ATTRIBUTE_VALUE,
+    entityType: "profile",
+    profileId: "alice-123",
+  },
+  expires: ExpirationTime.fromDays(30),
+})
 
 // 2. Create one relationship entity per skill
-const skills = ["frontend", "backend", "devops"];
-await walletClient.mutateEntities({
+const skills = ["frontend", "backend", "devops"]
+await walletClient.executeBatch({
   creates: skills.map((skill) => ({
     payload: jsonToPayload({ profileId: "alice-123", skill }),
     contentType: "application/json",
-    attributes: [
-      PROJECT_ATTRIBUTE,
-      { key: "entityType", value: "profileSkill" },
-      { key: "profileId", value: "alice-123" },
-      { key: "skill", value: skill },
-    ],
-    expiresIn: ExpirationTime.fromDays(30),
+    attributes: {
+      [PROJECT_ATTRIBUTE_NAME]: PROJECT_ATTRIBUTE_VALUE,
+      entityType: "profileSkill",
+      profileId: "alice-123",
+      skill,
+    },
+    expires: ExpirationTime.fromDays(30),
   })),
 });
 
@@ -118,7 +121,7 @@ await walletClient.mutateEntities({
 const frontendDevs = await publicClient
   .select({ key: true, payload: true })
   .where(
-    eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value),
+    eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE),
     eq("entityType", "profileSkill"),
     eq("skill", "frontend"),
   )
@@ -128,7 +131,7 @@ const frontendDevs = await publicClient
 const aliceSkills = await publicClient
   .select({ key: true, payload: true })
   .where(
-    eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value),
+    eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE),
     eq("entityType", "profileSkill"),
     eq("profileId", "alice-123"),
   )

--- a/skills/arkiv-best-practices/references/api-reference.md
+++ b/skills/arkiv-best-practices/references/api-reference.md
@@ -1,15 +1,15 @@
 # Arkiv JSON-RPC API Reference
 
-Arkiv exposes a JSON-RPC 2.0 API over HTTP. Use this when you need raw HTTP access without the SDK, or for advanced query options. All examples target the Cheesecake devnet.
+Arkiv exposes a JSON-RPC 2.0 API over HTTP. Use this when you need raw HTTP access without the SDK, or for advanced query options. All examples target the Tiramisu testnet.
 
 ## Endpoint
 
 | Property  | Value                                                         |
 | --------- | ------------------------------------------------------------- |
-| Chain ID  | `7733102` / `0x75ff6e`                                        |
-| HTTP RPC  | `https://rpc.cheesecake.db-chain.devnet.gobas.me`             |
-| WebSocket | `wss://rpc.cheesecake.db-chain.devnet.gobas.me`               |
-| Explorer  | `https://indexer.cheesecake.db-chain.devnet.gobas.me`         |
+| Chain ID  | `7738577` / `0x7614d1`                                        |
+| HTTP RPC  | `https://rpc.tiramisu.db-chain.testnet.arkiv.network`             |
+| WebSocket | `wss://rpc.tiramisu.db-chain.testnet.arkiv.network`               |
+| Explorer  | `https://indexer.tiramisu.db-chain.testnet.arkiv.network`         |
 | Faucet    | `https://hub.arkiv.network/faucet`                            |
 | API keys  | `https://hub.arkiv.network/api-keys`                          |
 
@@ -18,17 +18,17 @@ Register an API key at `https://hub.arkiv.network/api-keys` for elevated RPC rat
 ```bash
 # Path segment
 curl --json '{"jsonrpc":"2.0","id":1,"method":"arkiv_getEntityCount","params":[]}' \
-  https://rpc.cheesecake.db-chain.devnet.gobas.me/YOUR_API_KEY
+  https://rpc.tiramisu.db-chain.testnet.arkiv.network/YOUR_API_KEY
 
 # X-API-KEY header
 curl --json '{"jsonrpc":"2.0","id":1,"method":"arkiv_getEntityCount","params":[]}' \
   -H "X-API-KEY: YOUR_API_KEY" \
-  https://rpc.cheesecake.db-chain.devnet.gobas.me
+  https://rpc.tiramisu.db-chain.testnet.arkiv.network
 
 # Authorization: Bearer header
 curl --json '{"jsonrpc":"2.0","id":1,"method":"arkiv_getEntityCount","params":[]}' \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  https://rpc.cheesecake.db-chain.devnet.gobas.me
+  https://rpc.tiramisu.db-chain.testnet.arkiv.network
 ```
 
 ## Request Format
@@ -36,7 +36,7 @@ curl --json '{"jsonrpc":"2.0","id":1,"method":"arkiv_getEntityCount","params":[]
 All methods use standard JSON-RPC 2.0.
 
 ```bash
-curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+curl https://rpc.tiramisu.db-chain.testnet.arkiv.network \
   -H "content-type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"METHOD_NAME","params":[]}'
 ```
@@ -105,7 +105,7 @@ Use `*` to match all entities (cannot be combined with other predicates).
 **Example — query active NFTs:**
 
 ```bash
-curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+curl https://rpc.tiramisu.db-chain.testnet.arkiv.network \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":1,
@@ -120,7 +120,7 @@ curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
 **Example — query by owner:**
 
 ```bash
-curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+curl https://rpc.tiramisu.db-chain.testnet.arkiv.network \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":10,
@@ -135,7 +135,7 @@ curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
 **Example — numeric range:**
 
 ```bash
-curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+curl https://rpc.tiramisu.db-chain.testnet.arkiv.network \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":12,
@@ -147,7 +147,7 @@ curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
 **Example — prefix match with negation:**
 
 ```bash
-curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+curl https://rpc.tiramisu.db-chain.testnet.arkiv.network \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":13,
@@ -159,7 +159,7 @@ curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
 **Example — metadata only (omit payload):**
 
 ```bash
-curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+curl https://rpc.tiramisu.db-chain.testnet.arkiv.network \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":14,
@@ -244,7 +244,7 @@ Read a single entity by key. Returns all fields (full projection).
 | 1     | hex string | No       | Block number to read at (historical) |
 
 ```bash
-curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+curl https://rpc.tiramisu.db-chain.testnet.arkiv.network \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":5,
@@ -260,7 +260,7 @@ Returns `null` if the entity does not exist or has expired.
 Returns total number of entities currently stored. No parameters.
 
 ```bash
-curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+curl https://rpc.tiramisu.db-chain.testnet.arkiv.network \
   -H "content-type: application/json" \
   -d '{"jsonrpc":"2.0","id":3,"method":"arkiv_getEntityCount","params":[]}'
 ```

--- a/skills/arkiv-best-practices/references/api-reference.md
+++ b/skills/arkiv-best-practices/references/api-reference.md
@@ -1,23 +1,42 @@
 # Arkiv JSON-RPC API Reference
 
-Arkiv exposes a JSON-RPC 2.0 API over HTTP. Use this when you need raw HTTP access without the SDK, or for advanced query options.
+Arkiv exposes a JSON-RPC 2.0 API over HTTP. Use this when you need raw HTTP access without the SDK, or for advanced query options. All examples target the Cheesecake devnet.
 
 ## Endpoint
 
-| Property  | Value                                         |
-| --------- | --------------------------------------------- |
-| Chain ID  | `60138453102`                                 |
-| HTTP RPC  | `https://braga.hoodi.arkiv.network/rpc`       |
-| WebSocket | `wss://braga.hoodi.arkiv.network/rpc/ws`      |
-| Explorer  | `https://explorer.braga.hoodi.arkiv.network`  |
-| Faucet    | `https://braga.hoodi.arkiv.network/faucet`    |
+| Property  | Value                                                         |
+| --------- | ------------------------------------------------------------- |
+| Chain ID  | `7733102` / `0x75ff6e`                                        |
+| HTTP RPC  | `https://rpc.cheesecake.db-chain.devnet.gobas.me`             |
+| WebSocket | `wss://rpc.cheesecake.db-chain.devnet.gobas.me`               |
+| Explorer  | `https://indexer.cheesecake.db-chain.devnet.gobas.me`         |
+| Faucet    | `https://hub.arkiv.network/faucet`                            |
+| API keys  | `https://hub.arkiv.network/api-keys`                          |
+
+Register an API key at `https://hub.arkiv.network/api-keys` for elevated RPC rate limits. Pass the key as a URL path segment, or as an HTTP header:
+
+```bash
+# Path segment
+curl --json '{"jsonrpc":"2.0","id":1,"method":"arkiv_getEntityCount","params":[]}' \
+  https://rpc.cheesecake.db-chain.devnet.gobas.me/YOUR_API_KEY
+
+# X-API-KEY header
+curl --json '{"jsonrpc":"2.0","id":1,"method":"arkiv_getEntityCount","params":[]}' \
+  -H "X-API-KEY: YOUR_API_KEY" \
+  https://rpc.cheesecake.db-chain.devnet.gobas.me
+
+# Authorization: Bearer header
+curl --json '{"jsonrpc":"2.0","id":1,"method":"arkiv_getEntityCount","params":[]}' \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  https://rpc.cheesecake.db-chain.devnet.gobas.me
+```
 
 ## Request Format
 
 All methods use standard JSON-RPC 2.0.
 
 ```bash
-curl https://braga.hoodi.arkiv.network/rpc \
+curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
   -H "content-type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"METHOD_NAME","params":[]}'
 ```
@@ -26,7 +45,7 @@ curl https://braga.hoodi.arkiv.network/rpc \
 
 ### arkiv_query
 
-Query entities from the bitmap-backed SQLite store.
+Query entities from the indexed store.
 
 **Parameters:**
 
@@ -37,45 +56,63 @@ Query entities from the bitmap-backed SQLite store.
 
 **Query Syntax — Operators:**
 
-- Logical: `&&`, `||`
-- Negation: `!`
-- Comparisons: `=`, `!=`, `<`, `>`, `<=`, `>=`
-- Glob matching: `~` (match), `!~` (negated match)
+- Logical: `AND`, `OR`
+- Negation: `NOT`
+- Comparisons: `=`, `<`, `>`, `<=`, `>=`
+- Prefix matching: `STARTSWITH` (raw UTF-8 byte prefix on `str` attributes)
+
+**Reserved but not implemented:** `!=`, `EXISTS(…)`, `TYPEOF(…)`. Queries using these fail to parse. Use `NOT (attr = value)` for the complement — it also matches entities that never set the attribute.
+
+**Typed literals** — every value carries a type tag:
+
+| Type | Syntax | Example |
+| ---- | ------ | ------- |
+| bool | bare `true` / `false` | `flagged = true` |
+| i32 | bare number or `i32(n)` | `level >= 10` or `level >= i32(10)` |
+| u64 | `u64(n)` | `$expiresAt < u64(1200000)` |
+| u256 | `u256(n)` | `balance > u256(1000000)` |
+| dec | `dec("n.n")` | `score >= dec(3.5)` |
+| str | `str('text')` | `name = str('Bob')` |
+| addr | `addr(0x…)` | `$owner = addr(0xAbC…)` |
+| key | `key(0x…)` | `parent = key(0x123…)` |
+| bytes32 | `bytes32(0x…)` | `hash = bytes32(0xabc…)` |
+
+An untagged number always means `i32`. System block heights (`$expiresAt`, `$createdAt`) must be explicitly tagged as `u64`.
 
 **Synthetic Attributes (use with `$` prefix):**
 
-- `$owner` — Entity owner address
-- `$creator` — Entity creator address
 - `$key` — Entity key
-- `$expiration` — Expiration block
-- `$createdAtBlock` — Block at creation
-- `$sequence`, `$txIndex`, `$opIndex` — Ordering attributes
-- `$all` — Match all entities
+- `$owner` — Entity owner address (queryable)
+- `$creator` — Entity creator address (queryable)
+- `$expiresAt` — Expiration block (queryable, must use `u64` tag)
+- `$createdAt`, `$updatedAt`, `$creationFlags`, `$contentType`, `$payload` — returned in projections only, not queryable
+
+Use `*` to match all entities (cannot be combined with other predicates).
 
 **Options:**
 
-| Field          | Type       | Description                               |
-| -------------- | ---------- | ----------------------------------------- |
-| atBlock        | hex string | Query at specific block (e.g., `"0x1bc"`) |
-| includeData    | object     | Controls which fields are returned        |
-| resultsPerPage | hex string | Page size, max 200                        |
-| cursor         | string     | Pagination cursor from previous response  |
+| Field    | Type       | Description                                      |
+| -------- | ---------- | ------------------------------------------------ |
+| atBlock  | hex string | Query at specific block (default: latest)        |
+| select   | object     | Controls which fields are returned               |
+| limit    | hex/number | Page size, max 200 (default: 100)                |
+| cursor   | string     | Pagination cursor from previous response         |
 
-**includeData defaults (all true when omitted):**
+**select fields** (all opt-in; absent `select` returns key only):
 
-- key, contentType, payload, creator, owner, attributes, expiration
+`key`, `owner`, `creator`, `createdAt`, `updatedAt`, `expiresAt`, `creationFlags`, `contentType`, `payload`, `attributeSchema`, `attributes`
 
 **Example — query active NFTs:**
 
 ```bash
-curl https://braga.hoodi.arkiv.network/rpc \
+curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":1,
     "method":"arkiv_query",
     "params":[
-      "type = \"nft\" && status = \"active\"",
-      {"resultsPerPage":"0xa"}
+      "type = str(\"nft\") AND status = str(\"active\")",
+      {"limit":"0xa"}
     ]
   }'
 ```
@@ -83,13 +120,13 @@ curl https://braga.hoodi.arkiv.network/rpc \
 **Example — query by owner:**
 
 ```bash
-curl https://braga.hoodi.arkiv.network/rpc \
+curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":10,
     "method":"arkiv_query",
     "params":[
-      "$owner = \"0x2222222222222222222222222222222222222222\"",
+      "$owner = addr(0x2222222222222222222222222222222222222222)",
       null
     ]
   }'
@@ -98,42 +135,42 @@ curl https://braga.hoodi.arkiv.network/rpc \
 **Example — numeric range:**
 
 ```bash
-curl https://braga.hoodi.arkiv.network/rpc \
+curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":12,
     "method":"arkiv_query",
-    "params":["price >= 100 && price <= 1000", null]
+    "params":["price >= i32(100) AND price <= i32(1000)", null]
   }'
 ```
 
-**Example — glob match with negation:**
+**Example — prefix match with negation:**
 
 ```bash
-curl https://braga.hoodi.arkiv.network/rpc \
+curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":13,
     "method":"arkiv_query",
-    "params":["name ~ \"test*\" && !(status = \"deleted\")", null]
+    "params":["name STARTSWITH str(\"test\") AND NOT (status = str(\"deleted\"))", null]
   }'
 ```
 
 **Example — metadata only (omit payload):**
 
 ```bash
-curl https://braga.hoodi.arkiv.network/rpc \
+curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
   -H "content-type: application/json" \
   -d '{
     "jsonrpc":"2.0","id":14,
     "method":"arkiv_query",
     "params":[
-      "$all",
+      "*",
       {
-        "resultsPerPage":"0xa",
-        "includeData":{
+        "limit":"0xa",
+        "select":{
           "key":true,"attributes":true,"payload":false,
-          "contentType":true,"expiration":true,
+          "contentType":true,"expiresAt":true,
           "creator":true,"owner":true
         }
       }
@@ -151,15 +188,17 @@ curl https://braga.hoodi.arkiv.network/rpc \
     "data": [
       {
         "key": "0x...",
-        "value": "0x...",
         "contentType": "application/json",
-        "expiresAt": 1200000,
+        "payload": "0x...",
+        "expiresAt": "0x124f80",
         "creator": "0x...",
         "owner": "0x...",
-        "createdAtBlock": 401,
-        "lastModifiedAtBlock": 443,
-        "stringAttributes": [{ "key": "status", "value": "active" }],
-        "numericAttributes": [{ "key": "rarity", "value": 5 }]
+        "createdAt": "0x191",
+        "updatedAt": "0x1bb",
+        "attributes": [
+          { "name": "status", "type": "str", "value": "active" },
+          { "name": "rarity", "type": "i32", "value": 5 }
+        ]
       }
     ],
     "blockNumber": "0x1bc",
@@ -168,34 +207,65 @@ curl https://braga.hoodi.arkiv.network/rpc \
 }
 ```
 
-**Notes:**
+**Response encoding notes:**
 
-- `value` is hex-encoded bytes (decode to get payload)
-- `cursor` is omitted when no more pages remain
-- `blockNumber` is a hex string
+If you select a field, it appears in the response. If you do not select a field, it does not appear at all. The response never sends an unselected field as `null`.
+
+- `payload` is hex-encoded bytes. Decode it to read the entity content.
+- `createdAt`, `updatedAt`, and `expiresAt` are hex block numbers.
+- When no more pages remain, `cursor` is omitted.
+
+The `type` of an attribute decides the JSON encoding of its `value`:
+
+- `i32`: a JSON number
+- `u64` and `u256`: a `0x` hex quantity
+- `dec`: a decimal string
+- The byte-shaped types: `0x` bytes
+- `str`: a plain string
+- `bool`: a JSON boolean
 
 **Pagination:**
+
 Use the returned `cursor` in the next request:
 
 ```json
-{"method":"arkiv_query","params":["type = \"nft\"",{"cursor":"0x2a","resultsPerPage":"0x2"}]}
+{"method":"arkiv_query","params":["type = str(\"nft\")",{"cursor":"0x2a","limit":"0x2"}]}
 ```
+
+### arkiv_getEntity
+
+Read a single entity by key. Returns all fields (full projection).
+
+**Parameters:**
+
+| Index | Type       | Required | Description                          |
+| ----- | ---------- | -------- | ------------------------------------ |
+| 0     | hex string | Yes      | Entity key                           |
+| 1     | hex string | No       | Block number to read at (historical) |
+
+```bash
+curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
+  -H "content-type: application/json" \
+  -d '{
+    "jsonrpc":"2.0","id":5,
+    "method":"arkiv_getEntity",
+    "params":["0xYOUR_ENTITY_KEY"]
+  }'
+```
+
+Returns `null` if the entity does not exist or has expired.
 
 ### arkiv_getEntityCount
 
 Returns total number of entities currently stored. No parameters.
 
 ```bash
-curl https://braga.hoodi.arkiv.network/rpc \
+curl https://rpc.cheesecake.db-chain.devnet.gobas.me \
   -H "content-type: application/json" \
   -d '{"jsonrpc":"2.0","id":3,"method":"arkiv_getEntityCount","params":[]}'
 ```
 
 Result: plain JSON number (e.g., `18427`).
-
-### arkiv_getNumberOfUsedSlots
-
-Returns used storage-accounting slots. No parameters. Result is a hex string.
 
 ### arkiv_getBlockTiming
 

--- a/skills/arkiv-best-practices/references/api-reference.md
+++ b/skills/arkiv-best-practices/references/api-reference.md
@@ -85,7 +85,8 @@ An untagged number always means `i32`. System block heights (`$expiresAt`, `$cre
 - `$owner` — Entity owner address (queryable)
 - `$creator` — Entity creator address (queryable)
 - `$expiresAt` — Expiration block (queryable, must use `u64` tag)
-- `$createdAt`, `$updatedAt`, `$creationFlags`, `$contentType`, `$payload` — returned in projections only, not queryable
+- `$createdAt` — Creation block (queryable, must use `u64` tag)
+- `$updatedAt`, `$creationFlags`, `$contentType`, `$payload` — returned in projections only, not queryable
 
 Use `*` to match all entities (cannot be combined with other predicates).
 

--- a/skills/arkiv-best-practices/references/integration-patterns.md
+++ b/skills/arkiv-best-practices/references/integration-patterns.md
@@ -1,14 +1,17 @@
 # Arkiv Integration Patterns
 
-The three most common integration scenarios for Arkiv applications.
-
-All examples in this file assume `@arkiv-network/sdk` version `0.7.0` or higher, where viem is a peer dependency (`npm install @arkiv-network/sdk viem`) and `http`/`custom`/`privateKeyToAccount` import from `viem` / `viem/accounts`. Check the user's installed SDK version first: on `0.6.x` those helpers import from the SDK itself and queries use `buildQuery()` instead of `select()`; below `0.6.5` the `braga` chain export does not exist. Only recommend an upgrade if the project is below the minimum it actually needs.
+The three most common integration scenarios for Arkiv applications. All examples target `@arkiv-network/sdk@0.8.0-dev.3` on the Cheesecake devnet.
 
 ## Table of Contents
 
-1. [Backend Read/Write](#backend-readwrite)
-2. [Client-Side Reading (React Hook)](#client-side-reading)
-3. [Client-Side Writing (Wallet Integration)](#client-side-writing)
+- [Arkiv Integration Patterns](#arkiv-integration-patterns)
+  - [Table of Contents](#table-of-contents)
+  - [Backend Read/Write](#backend-readwrite)
+  - [Client-Side Reading](#client-side-reading)
+  - [Client-Side Writing](#client-side-writing)
+    - [Option A: Manual MetaMask integration](#option-a-manual-metamask-integration)
+    - [Option B: Wagmi / RainbowKit integration (recommended for dApps)](#option-b-wagmi--rainbowkit-integration-recommended-for-dapps)
+  - [Live Events with TanStack Query](#live-events-with-tanstack-query)
 
 ---
 
@@ -18,37 +21,40 @@ For server-side applications (Next.js API routes, Express, any Node.js backend).
 
 ```typescript
 // lib/arkiv-server.ts
-import { createWalletClient, createPublicClient } from "@arkiv-network/sdk"
-import { braga } from "@arkiv-network/sdk/chains"
-import { ExpirationTime, jsonToPayload } from "@arkiv-network/sdk/utils"
+import { createWalletClient, createPublicClient, ExpirationTime, jsonToPayload } from "@arkiv-network/sdk"
+import { cheesecake } from "@arkiv-network/sdk/chains"
 import { eq } from "@arkiv-network/sdk/query"
 import { http } from "viem"
 import { privateKeyToAccount } from "viem/accounts"
-import { PROJECT_ATTRIBUTE } from "./arkiv" // your project attribute
+import { PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE } from "./arkiv"
 
-// Initialize clients ONCE at module level
+// Include your API key in the URL: https://rpc.cheesecake.db-chain.devnet.gobas.me/<api-key>
+// Obtained from the Arkiv Hub: https://hub.arkiv.network
+const rpcUrl = process.env.CHEESECAKE_RPC_URL
+
+
 const walletClient = createWalletClient({
-  chain: braga,
-  transport: http(),
+  chain: cheesecake,
+  transport: http(rpcUrl),
   account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
-})
+});
 
 const publicClient = createPublicClient({
-  chain: braga,
-  transport: http(),
-})
+  chain: cheesecake,
+  transport: http(rpcUrl),
+});
 
 // Write example
 export async function createPost(title: string, content: string) {
   const { entityKey, txHash } = await walletClient.createEntity({
     payload: jsonToPayload({ title, content }),
     contentType: "application/json",
-    attributes: [
-      PROJECT_ATTRIBUTE,
-      { key: "entityType", value: "post" },
-      { key: "created", value: Date.now() },
-    ],
-    expiresIn: ExpirationTime.fromDays(30),
+    attributes: {
+      [PROJECT_ATTRIBUTE_NAME]: PROJECT_ATTRIBUTE_VALUE,
+      entityType: "post",
+      created: Date.now(),
+    },
+    expires: ExpirationTime.fromDays(30),
   })
   return { entityKey, txHash }
 }
@@ -58,12 +64,20 @@ export async function getPosts() {
   const result = await publicClient
     .select({ key: true, payload: true })
     .where(
-      eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value),
+      eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE),
       eq("entityType", "post"),
     )
     .limit(50)
     .fetch()
   return result
+}
+
+export async function updatePostStatus(entityKey: `0x${string}`, status: string) {
+  const { txHash } = await walletClient.patchEntity({
+    entityKey,
+    set: { status },
+  })
+  return { txHash }
 }
 ```
 
@@ -114,37 +128,33 @@ app.listen(3000)
 
 For frontend applications that only need to query data. Uses a public client — no private key, safe to run in the browser.
 
-First, define the fetcher functions separately from hooks — these are reusable and testable:
-
 ```typescript
 // lib/arkiv-queries.ts
 import { createPublicClient } from "@arkiv-network/sdk"
-import { braga } from "@arkiv-network/sdk/chains"
+import { cheesecake } from "@arkiv-network/sdk/chains"
 import { eq } from "@arkiv-network/sdk/query"
 import { http } from "viem"
-import { PROJECT_ATTRIBUTE } from "@/lib/arkiv"
+import { PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE } from "@/lib/arkiv"
 
-// Single public client instance — reuse across all queries
 export const publicClient = createPublicClient({
-  chain: braga,
-  transport: http(),
+  chain: cheesecake,
+  transport: http(process.env.NEXT_PUBLIC_CHEESECAKE_RPC_URL),
 })
 
 export async function fetchEntitiesByType<T>(entityType: string): Promise<(T & { arkivEntityKey: string })[]> {
   const result = await publicClient
     .select({ key: true, payload: true })
     .where(
-      eq(PROJECT_ATTRIBUTE.key, PROJECT_ATTRIBUTE.value),
+      eq(PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE),
       eq("entityType", entityType),
     )
     .limit(50)
     .fetch()
 
-  // Combine entity key with payload — gives each item a stable unique identifier
   return result.entities
     .map((entity) => {
       try {
-        return { arkivEntityKey: entity.key, ...entity.toJson() }
+        return { arkivEntityKey: entity.key!, ...entity.toJson() }
       } catch {
         return null
       }
@@ -153,26 +163,18 @@ export async function fetchEntitiesByType<T>(entityType: string): Promise<(T & {
 }
 
 export async function fetchEntityByKey<T>(entityKey: string): Promise<T> {
-  const entity = await publicClient.getEntity(entityKey)
+  const entity = await publicClient.getEntity(entityKey as `0x${string}`)
   return entity.toJson()
 }
 ```
 
-Then wrap them in hooks. Use TanStack Query (`@tanstack/react-query`) for caching, deduplication, and background refetching. **If the project already has a data-fetching library (SWR, Apollo, etc.), use that instead.** If nothing is set up yet, suggest installing TanStack Query:
-
-```bash
-npm install @tanstack/react-query
-```
+Wrap them in hooks with TanStack Query (`@tanstack/react-query`):
 
 ```typescript
 // hooks/useArkivQuery.ts
 import { useQuery } from "@tanstack/react-query"
 import { fetchEntitiesByType, fetchEntityByKey } from "@/lib/arkiv-queries"
 
-/**
- * Fetch a list of entities by type.
- * Uses TanStack Query for caching and automatic refetching.
- */
 export function useArkivQuery<T>(entityType: string) {
   return useQuery<T[]>({
     queryKey: ["arkiv", "entities", entityType],
@@ -180,10 +182,6 @@ export function useArkivQuery<T>(entityType: string) {
   })
 }
 
-/**
- * Fetch a single entity by key.
- * Only runs when entityKey is truthy.
- */
 export function useArkivEntity<T>(entityKey: string | null) {
   return useQuery<T>({
     queryKey: ["arkiv", "entity", entityKey],
@@ -231,8 +229,6 @@ For dApps where the user's own wallet signs transactions. Two approaches dependi
 
 ### Option A: Manual MetaMask integration
 
-Use this if you're not using wagmi or a wallet framework. You need to handle network switching yourself.
-
 **Adding the Arkiv network to MetaMask:**
 
 ```typescript
@@ -240,11 +236,11 @@ async function addArkivNetwork() {
   await window.ethereum.request({
     method: "wallet_addEthereumChain",
     params: [{
-      chainId: "0xe0087f86e",
-      chainName: "Arkiv Braga Testnet",
+      chainId: "0x75ff6e",
+      chainName: "Arkiv Cheesecake Testnet",
       nativeCurrency: { name: "GLM", symbol: "GLM", decimals: 18 },
-      rpcUrls: ["https://braga.hoodi.arkiv.network/rpc"],
-      blockExplorerUrls: ["https://explorer.braga.hoodi.arkiv.network"],
+      rpcUrls: ["https://rpc.cheesecake.db-chain.devnet.gobas.me"],
+      blockExplorerUrls: ["https://indexer.cheesecake.db-chain.devnet.gobas.me"],
     }],
   })
 }
@@ -254,39 +250,32 @@ async function addArkivNetwork() {
 
 ```typescript
 import { createWalletClient } from "@arkiv-network/sdk"
-import { braga } from "@arkiv-network/sdk/chains"
+import { cheesecake } from "@arkiv-network/sdk/chains"
 import { custom } from "viem"
 
 await addArkivNetwork()
-const [address] = await window.ethereum.request({ method: "eth_requestAccounts" })
+await window.ethereum.request({ method: "eth_requestAccounts" })
 
 const walletClient = createWalletClient({
-  chain: braga,
+  chain: cheesecake,
   transport: custom(window.ethereum),
 })
 ```
 
 ### Option B: Wagmi / RainbowKit integration (recommended for dApps)
 
-If your project already uses wagmi (or a wagmi-powered framework like RainbowKit, ConnectKit, etc.), you can derive an Arkiv wallet client directly from the wagmi wallet client. This avoids duplicate wallet connection logic.
-
 ```tsx
-import { useAccount, useWalletClient } from "wagmi";
-import { createWalletClient as createArkivWalletClient } from "@arkiv-network/sdk";
-import { braga } from "@arkiv-network/sdk/chains";
-import { custom } from "viem";
+import { useAccount, useWalletClient } from "wagmi"
+import { createWalletClient as createArkivWalletClient } from "@arkiv-network/sdk"
+import { cheesecake } from "@arkiv-network/sdk/chains"
+import { custom } from "viem"
 
-// Inside your component:
-const { address } = useAccount();
-const { data: wagmiWalletClient } = useWalletClient();
-
-if (!wagmiWalletClient) {
-  // throw or return loading UI
-}
+const { address } = useAccount()
+const { data: wagmiWalletClient } = useWalletClient()
 
 const arkivWalletClient = createArkivWalletClient({
-  chain: braga,
-  transport: custom(wagmiWalletClient.transport),
+  chain: cheesecake,
+  transport: custom(wagmiWalletClient!.transport),
   account: address,
 });
 ```
@@ -294,17 +283,64 @@ const arkivWalletClient = createArkivWalletClient({
 Then use `arkivWalletClient` the same way as any other wallet client:
 
 ```typescript
-import { jsonToPayload, ExpirationTime } from "@arkiv-network/sdk/utils"
-import { PROJECT_ATTRIBUTE } from "@/lib/arkiv"
+import { jsonToPayload, ExpirationTime } from "@arkiv-network/sdk"
+import { PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE } from "@/lib/arkiv"
 
 const { entityKey, txHash } = await arkivWalletClient.createEntity({
   payload: jsonToPayload({ title: "My Post", content: "Hello!" }),
   contentType: "application/json",
-  attributes: [
-    PROJECT_ATTRIBUTE,
-    { key: "entityType", value: "post" },
-    { key: "author", value: address },
-  ],
-  expiresIn: ExpirationTime.fromDays(30),
+  attributes: {
+    [PROJECT_ATTRIBUTE_NAME]: PROJECT_ATTRIBUTE_VALUE,
+    entityType: "post",
+    author: address,
+  },
+  expires: ExpirationTime.fromDays(30),
 })
 ```
+
+---
+
+## Live Events with TanStack Query
+
+Use `watchEntityEvents` to invalidate TanStack Query caches when entities change on-chain. Do not await the return value — it is the unwatch function:
+
+```typescript
+// lib/arkiv-events.ts
+import { useEffect } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { publicClient } from "@/lib/arkiv-queries"
+import { PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE } from "@/lib/arkiv"
+
+export function useArkivEventWatcher(entityType: string) {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    const unwatch = publicClient.watchEntityEvents({
+      onEntityCreated: () => {
+        queryClient.invalidateQueries({ queryKey: ["arkiv", "entities", entityType] })
+      },
+      onEntityPatched: () => {
+        queryClient.invalidateQueries({ queryKey: ["arkiv", "entities", entityType] })
+      },
+      onEntityDeleted: () => {
+        queryClient.invalidateQueries({ queryKey: ["arkiv", "entities", entityType] })
+      },
+      onError: (error) => console.error("Arkiv event error:", error),
+    })
+
+    return unwatch
+  }, [queryClient, entityType])
+}
+```
+
+Mount the hook alongside your query hook:
+
+```tsx
+function PostList() {
+  useArkivEventWatcher("post")
+  const { data: posts, isLoading } = useArkivQuery<Post>("post")
+  // ...
+}
+```
+
+**Note:** Expiration fires no event in 0.8. To detect expired entities, poll with `getEntity()` and handle `NoEntityFoundError`, or query by `$expiresAt`.

--- a/skills/arkiv-best-practices/references/integration-patterns.md
+++ b/skills/arkiv-best-practices/references/integration-patterns.md
@@ -1,6 +1,6 @@
 # Arkiv Integration Patterns
 
-The three most common integration scenarios for Arkiv applications. All examples target `@arkiv-network/sdk@0.8.0-dev.3` on the Cheesecake devnet.
+The three most common integration scenarios for Arkiv applications. All examples target `@arkiv-network/sdk@0.8.0-dev.3` on the Tiramisu testnet.
 
 ## Table of Contents
 
@@ -22,25 +22,25 @@ For server-side applications (Next.js API routes, Express, any Node.js backend).
 ```typescript
 // lib/arkiv-server.ts
 import { createWalletClient, createPublicClient, ExpirationTime, jsonToPayload } from "@arkiv-network/sdk"
-import { cheesecake } from "@arkiv-network/sdk/chains"
+import { tiramisu } from "@arkiv-network/sdk/chains"
 import { eq } from "@arkiv-network/sdk/query"
 import { http } from "viem"
 import { privateKeyToAccount } from "viem/accounts"
 import { PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE } from "./arkiv"
 
-// Include your API key in the URL: https://rpc.cheesecake.db-chain.devnet.gobas.me/<api-key>
+// Include your API key in the URL: https://rpc.tiramisu.db-chain.testnet.arkiv.network/<api-key>
 // Obtained from the Arkiv Hub: https://hub.arkiv.network
-const rpcUrl = process.env.CHEESECAKE_RPC_URL
+const rpcUrl = process.env.TIRAMISU_RPC_URL
 
 
 const walletClient = createWalletClient({
-  chain: cheesecake,
+  chain: tiramisu,
   transport: http(rpcUrl),
   account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
 });
 
 const publicClient = createPublicClient({
-  chain: cheesecake,
+  chain: tiramisu,
   transport: http(rpcUrl),
 });
 
@@ -131,14 +131,14 @@ For frontend applications that only need to query data. Uses a public client —
 ```typescript
 // lib/arkiv-queries.ts
 import { createPublicClient } from "@arkiv-network/sdk"
-import { cheesecake } from "@arkiv-network/sdk/chains"
+import { tiramisu } from "@arkiv-network/sdk/chains"
 import { eq } from "@arkiv-network/sdk/query"
 import { http } from "viem"
 import { PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE } from "@/lib/arkiv"
 
 export const publicClient = createPublicClient({
-  chain: cheesecake,
-  transport: http(process.env.NEXT_PUBLIC_CHEESECAKE_RPC_URL),
+  chain: tiramisu,
+  transport: http(process.env.NEXT_PUBLIC_TIRAMISU_RPC_URL),
 })
 
 export async function fetchEntitiesByType<T>(entityType: string): Promise<(T & { arkivEntityKey: string })[]> {
@@ -236,11 +236,11 @@ async function addArkivNetwork() {
   await window.ethereum.request({
     method: "wallet_addEthereumChain",
     params: [{
-      chainId: "0x75ff6e",
-      chainName: "Arkiv Cheesecake Testnet",
+      chainId: "0x7614d1",
+      chainName: "Arkiv Tiramisu Testnet",
       nativeCurrency: { name: "GLM", symbol: "GLM", decimals: 18 },
-      rpcUrls: ["https://rpc.cheesecake.db-chain.devnet.gobas.me"],
-      blockExplorerUrls: ["https://indexer.cheesecake.db-chain.devnet.gobas.me"],
+      rpcUrls: ["https://rpc.tiramisu.db-chain.testnet.arkiv.network"],
+      blockExplorerUrls: ["https://indexer.tiramisu.db-chain.testnet.arkiv.network"],
     }],
   })
 }
@@ -250,14 +250,14 @@ async function addArkivNetwork() {
 
 ```typescript
 import { createWalletClient } from "@arkiv-network/sdk"
-import { cheesecake } from "@arkiv-network/sdk/chains"
+import { tiramisu } from "@arkiv-network/sdk/chains"
 import { custom } from "viem"
 
 await addArkivNetwork()
 await window.ethereum.request({ method: "eth_requestAccounts" })
 
 const walletClient = createWalletClient({
-  chain: cheesecake,
+  chain: tiramisu,
   transport: custom(window.ethereum),
 })
 ```
@@ -267,14 +267,14 @@ const walletClient = createWalletClient({
 ```tsx
 import { useAccount, useWalletClient } from "wagmi"
 import { createWalletClient as createArkivWalletClient } from "@arkiv-network/sdk"
-import { cheesecake } from "@arkiv-network/sdk/chains"
+import { tiramisu } from "@arkiv-network/sdk/chains"
 import { custom } from "viem"
 
 const { address } = useAccount()
 const { data: wagmiWalletClient } = useWalletClient()
 
 const arkivWalletClient = createArkivWalletClient({
-  chain: cheesecake,
+  chain: tiramisu,
   transport: custom(wagmiWalletClient!.transport),
   account: address,
 });

--- a/skills/arkiv-best-practices/references/integration-patterns.md
+++ b/skills/arkiv-best-practices/references/integration-patterns.md
@@ -309,7 +309,6 @@ Use `watchEntityEvents` to invalidate TanStack Query caches when entities change
 import { useEffect } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { publicClient } from "@/lib/arkiv-queries"
-import { PROJECT_ATTRIBUTE_NAME, PROJECT_ATTRIBUTE_VALUE } from "@/lib/arkiv"
 
 export function useArkivEventWatcher(entityType: string) {
   const queryClient = useQueryClient()

--- a/skills/arkiv-best-practices/references/migration-guide.md
+++ b/skills/arkiv-best-practices/references/migration-guide.md
@@ -1,111 +1,123 @@
-# Kaolin to Braga Migration Guide
+# Braga to Cheesecake Migration Guide
 
-Use this guide when the user already has an Arkiv project that targets Kaolin and needs to move it to Braga.
+Use this guide when the user already has an Arkiv project that targets Braga and needs to move it to Cheesecake, including upgrading from SDK 0.7.x to 0.8.0-dev.3.
 
-## What Changes
+## What Changed
 
-- The SDK API stays the same.
-- The `braga` chain export requires `@arkiv-network/sdk` version `0.6.5` or higher.
-- The chain target changes from `kaolin` to `braga`.
-- The active RPC, WebSocket, faucet, explorer, and chain ID all change.
-- Braga uses `GLM` as the native gas token instead of test ETH.
-- Testnet state does not migrate: entities written to Kaolin stay on Kaolin.
+- Braga was **retired on 12 August 2026**. Its endpoints no longer respond.
+- The chain target changes from `braga` to `cheesecake`.
+- The SDK has a **breaking API change** from 0.7.x to 0.8.0-dev.3 — not just a version bump.
+- Braga entity state does **not** migrate: entities written to Braga stay on Braga.
 
-## Sunset Window
+## Network Values
 
-- Kaolin and Braga can run in parallel until `15 May 2026`.
-- After that date, Kaolin endpoints stop responding.
+| Property | Cheesecake value |
+| -------- | ---------------- |
+| Chain ID | `7733102` / `0x75ff6e` |
+| HTTP RPC | `https://rpc.cheesecake.db-chain.devnet.gobas.me` |
+| WebSocket RPC | `wss://rpc.cheesecake.db-chain.devnet.gobas.me` |
+| Block explorer | `https://indexer.cheesecake.db-chain.devnet.gobas.me` |
+| Faucet | `https://hub.arkiv.network/faucet` (0.1 GLM, 24h cooldown, wallet + SIWE required) |
+| API keys | `https://hub.arkiv.network/api-keys` (elevated RPC rate limits) |
+| Native gas token | `GLM` |
+| Bridge address | **Not published** — ask on [Discord](https://discord.gg/arkiv) |
 
 ## Migration Checklist
 
-### 1. Update SDK chain imports
+### 1. Update SDK version
 
-Before changing imports, verify that the project is already on `@arkiv-network/sdk` `0.6.5` or newer. Do not pin a replacement install command by default; tell the user to check the current SDK version and upgrade only if the project is below the minimum needed for `braga`.
+Install the dev release — npm `latest` is still 0.7.0:
+
+```bash
+npm install @arkiv-network/sdk@dev viem
+# or
+bun add @arkiv-network/sdk@dev viem
+```
+
+Verify the installed version is `0.8.0-dev.3` or newer.
+
+### 2. Update chain imports
 
 ```diff
-- import { kaolin } from "@arkiv-network/sdk/chains";
-+ import { braga } from "@arkiv-network/sdk/chains";
+- import { braga } from "@arkiv-network/sdk/chains";
++ import { cheesecake } from "@arkiv-network/sdk/chains";
 
   const client = createWalletClient({
--   chain: kaolin,
-+   chain: braga,
-    transport: http(),
+-   chain: braga,
++   chain: cheesecake,
+    transport: http(process.env.CHEESECAKE_RPC_URL),
     account,
   });
 ```
 
-Apply the same swap for `createWalletClient`, `createPublicClient`, wagmi-derived Arkiv clients, and any custom chain constants that still point to Kaolin.
+Apply the same swap for `createWalletClient`, `createPublicClient`, wagmi-derived Arkiv clients, and any custom chain constants.
 
-If the SDK upgrade lands on `0.7.0` or newer, additional breaking changes apply beyond the chain swap: viem becomes a peer dependency (`npm install @arkiv-network/sdk viem`), `http`/`custom`/`privateKeyToAccount` move to `viem` / `viem/accounts`, queries migrate from `buildQuery()` to `select()`, and `orderBy`/`asc`/`desc` become deprecated no-ops. Follow the "Upgrading to SDK 0.7.0" checklist in SKILL.md alongside this guide.
-
-### 2. Replace network constants and wallet settings
-
-Use these Braga values everywhere the project configures the network:
-
-| Property | Braga value |
-| -------- | ----------- |
-| Chain ID | `60138453102` / `0xe0087f86e` |
-| HTTP RPC | `https://braga.hoodi.arkiv.network/rpc` |
-| WebSocket RPC | `wss://braga.hoodi.arkiv.network/rpc/ws` |
-| Explorer | `https://explorer.braga.hoodi.arkiv.network` |
-| Faucet | `https://braga.hoodi.arkiv.network/faucet/` |
-| Native gas token | `GLM` |
-
-If the project adds the network to MetaMask or viem manually, update:
-
-- `chainId`
-- `chainName`
-- `rpcUrls`
-- `blockExplorers`
-- `nativeCurrency` so the symbol is `GLM`
+If the project adds the network to MetaMask or viem manually, update `chainId`, `chainName`, `rpcUrls`, `blockExplorers`, and `nativeCurrency` (symbol `GLM`).
 
 ### 3. Rename env vars and config keys
 
-Do not leave mixed Kaolin and Braga names in active codepaths. Rename env vars so the environment clearly reflects the current target network:
-
 ```diff
-- KAOLIN_RPC_URL=https://kaolin.hoodi.arkiv.network/rpc
-+ BRAGA_RPC_URL=https://braga.hoodi.arkiv.network/rpc
+- BRAGA_RPC_URL=https://braga.hoodi.arkiv.network/rpc
++ CHEESECAKE_RPC_URL=https://rpc.cheesecake.db-chain.devnet.gobas.me/<your-api-key>
++ CHEESECAKE_API_KEY=your-key-from-hub
 ```
 
-Check these places for stale Kaolin references:
+Register an API key at `https://hub.arkiv.network/api-keys` and pass it as a URL path segment, `X-API-KEY` header, or `Authorization: Bearer` header. Without a key, anonymous RPC access is rate-limited.
 
-- `.env*` files
-- deployment configs
-- Docker or container env wiring
-- shell scripts and seed scripts
-- README setup steps
-- frontend wallet config
+Check `.env*` files, deployment configs, Docker wiring, shell/seed scripts, README setup steps, and frontend wallet config for stale Braga references.
 
-### 4. Refresh funding and bridge configuration
+### 4. Apply SDK 0.7 → 0.8 API changes
 
-- Request fresh test `GLM` from the Braga faucet.
-- If the app bridges programmatically, update the Standard Bridge address to `0xB52b417A79c9dE21ffe221dF9a3821B7EaC60813`.
-- Funds already bridged into Kaolin stay there; withdraw them before the sunset if needed.
+These ship together — apply all of them:
 
-### 5. Re-create entities and seed data
+| 0.7.x (old) | 0.8.0-dev.3 (new) |
+| ----------- | ----------------- |
+| `import { … } from "@arkiv-network/sdk/utils"` | Import `ExpirationTime`, `jsonToPayload`, `stringToPayload` from `@arkiv-network/sdk` root |
+| `payloadToString(entity.payload)` | `entity.toText()` or `entity.toJson()` |
+| `attributes: [{ key: "type", value: "note" }]` | `attributes: { type: "note" }` |
+| `entity.attributes.find(a => a.key === "x")?.value` | `entity.attributes.x?.value` (object keyed by name) |
+| `expiresIn: ExpirationTime.fromHours(12)` | `expires: ExpirationTime.fromHours(12)` |
+| `walletClient.updateEntity({ entityKey, payload, contentType, attributes, expiresIn })` | `walletClient.patchEntity({ entityKey, set: { status: "done" }, unset: ["draft"] })` |
+| `walletClient.mutateEntities({ creates, updates, deletes, extensions })` | `walletClient.executeBatch({ creates, patches, deletes, extensions, ownershipChanges })` |
+| `subscribeEntityEvents(...)` (async, returns Promise) | `watchEntityEvents(...)` (sync, returns unwatch function — do not await) |
+| `InvalidAttributeError` | `InvalidValueError` |
+| `InvalidExpirationError` | `InvalidExpiryError` |
+| `orderBy()` / `asc()` / `desc()` (deprecated no-ops) | **Removed** — sort client-side |
+| `expiresAtBlock`, `createdAtBlock`, `lastModifiedAtBlock` | `expiresAt`, `createdAt`, `updatedAt` |
+| Bare float `19.99` as attribute value | `dec("19.99")` from `@arkiv-network/sdk/attr` |
 
-Kaolin entities do not migrate to Braga. If the app depends on seed data, startup entities, cached indexes, or demo content, run the seed/migration script against Braga before switching traffic.
+**New methods in 0.8:** `changeOwnership()`, `executeBatch()`.
 
-Pay special attention to:
+**New typed attribute helpers** from `@arkiv-network/sdk/attr`: `bool`, `i32`, `u64`, `u256`, `dec`, `decFromUnits`, `decUnits`, `str`, `addr`, `key`, `bytes32`.
 
-- entities loaded at app startup
-- admin-created demo data
-- test fixtures used by integration tests
-- dashboards that assume existing rows are already present
+**New expiry helpers:** `ExpirationTime.fromSeconds()`, `fromWeeks()`, `fromMonths()`, `fromYears()`, `fromBlocks()`, `atBlock()`, `atDate()`, `permanent()`.
 
-### 6. Verify both read and write paths
+**Event handler renames:** `onEntityUpdated` → `onEntityPatched`, `onEntityExpiresInExtended` → `onExpiryExtended`. New: `onOwnershipTransferred`, `onEvent`. `onEntityExpired` is **gone** — expiration fires no event; poll or handle `NoEntityFoundError` from `getEntity()`.
 
-After updating the network target:
+**Query operators:** `ne()`, `exists()`, and `hasType()` are exported by the SDK but **not implemented on the node** — queries using them fail to parse. Use `not(eq(...))` instead.
 
-- run one write flow end-to-end
-- verify queries return the newly written entity
-- confirm wallet prompts show Braga, not Kaolin
-- confirm gas is charged in `GLM`
+### 5. Refresh funding
+
+- Request fresh test GLM from the [Cheesecake faucet](https://hub.arkiv.network/faucet).
+- No bridge address is published for Cheesecake. Funds on Braga stay there.
+
+### 6. Re-create entities and seed data
+
+Braga entities do not migrate. If the app depends on seed data, startup entities, cached indexes, or demo content, run the seed/migration script against Cheesecake before switching traffic.
+
+### 7. Verify both read and write paths
+
+After updating:
+
+- Run one write flow end-to-end (`createEntity`)
+- Verify queries return the newly written entity
+- Confirm wallet prompts show Cheesecake, not Braga
+- Confirm gas is charged in `GLM`
+- Test a partial update with `patchEntity` (not a full replace)
 
 ## Migration Notes for Agents
 
-- Prefer narrow replacements: change active codepaths to Braga, then remove or isolate Kaolin-only compatibility code.
-- Keep Kaolin references only in migration docs, temporary fallback configs, or explicit legacy support blocks.
-- If the codebase uses direct viem or wagmi chain definitions instead of the Arkiv exported chain, update `id`, `rpcUrls`, `blockExplorers`, and `nativeCurrency` consistently.
-- If an app must run both networks during the overlap period, keep the network selection explicit and label data sources clearly to avoid mixing Kaolin and Braga entities.
+- Prefer narrow replacements: change active codepaths to Cheesecake, then remove Braga-only compatibility code.
+- Keep Braga references only in migration docs or explicit legacy support blocks.
+- If the codebase uses direct viem or wagmi chain definitions instead of the Arkiv exported chain, update `id`, `rpcUrls`, and `nativeCurrency` consistently.
+- Do not teach users to hand-build raw entity mutation transactions — the SDK handles encoding internally via the Arkiv precompile at `0x4400000000000000000000000000000000000044`.

--- a/skills/arkiv-best-practices/references/migration-guide.md
+++ b/skills/arkiv-best-practices/references/migration-guide.md
@@ -1,22 +1,22 @@
-# Braga to Cheesecake Migration Guide
+# Braga to Tiramisu Migration Guide
 
-Use this guide when the user already has an Arkiv project that targets Braga and needs to move it to Cheesecake, including upgrading from SDK 0.7.x to 0.8.0-dev.3.
+Use this guide when the user already has an Arkiv project that targets Braga and needs to move it to Tiramisu, including upgrading from SDK 0.7.x to 0.8.0-dev.3.
 
 ## What Changed
 
 - Braga was **retired on 12 August 2026**. Its endpoints no longer respond.
-- The chain target changes from `braga` to `cheesecake`.
+- The chain target changes from `braga` to `tiramisu`.
 - The SDK has a **breaking API change** from 0.7.x to 0.8.0-dev.3 — not just a version bump.
 - Braga entity state does **not** migrate: entities written to Braga stay on Braga.
 
 ## Network Values
 
-| Property | Cheesecake value |
+| Property | Tiramisu value |
 | -------- | ---------------- |
-| Chain ID | `7733102` / `0x75ff6e` |
-| HTTP RPC | `https://rpc.cheesecake.db-chain.devnet.gobas.me` |
-| WebSocket RPC | `wss://rpc.cheesecake.db-chain.devnet.gobas.me` |
-| Block explorer | `https://indexer.cheesecake.db-chain.devnet.gobas.me` |
+| Chain ID | `7738577` / `0x7614d1` |
+| HTTP RPC | `https://rpc.tiramisu.db-chain.testnet.arkiv.network` |
+| WebSocket RPC | `wss://rpc.tiramisu.db-chain.testnet.arkiv.network` |
+| Block explorer | `https://indexer.tiramisu.db-chain.testnet.arkiv.network` |
 | Faucet | `https://hub.arkiv.network/faucet` (0.1 GLM, 24h cooldown, wallet + SIWE required) |
 | API keys | `https://hub.arkiv.network/api-keys` (elevated RPC rate limits) |
 | Native gas token | `GLM` |
@@ -40,12 +40,12 @@ Verify the installed version is `0.8.0-dev.3` or newer.
 
 ```diff
 - import { braga } from "@arkiv-network/sdk/chains";
-+ import { cheesecake } from "@arkiv-network/sdk/chains";
++ import { tiramisu } from "@arkiv-network/sdk/chains";
 
   const client = createWalletClient({
 -   chain: braga,
-+   chain: cheesecake,
-    transport: http(process.env.CHEESECAKE_RPC_URL),
++   chain: tiramisu,
+    transport: http(process.env.TIRAMISU_RPC_URL),
     account,
   });
 ```
@@ -58,8 +58,8 @@ If the project adds the network to MetaMask or viem manually, update `chainId`, 
 
 ```diff
 - BRAGA_RPC_URL=https://braga.hoodi.arkiv.network/rpc
-+ CHEESECAKE_RPC_URL=https://rpc.cheesecake.db-chain.devnet.gobas.me/<your-api-key>
-+ CHEESECAKE_API_KEY=your-key-from-hub
++ TIRAMISU_RPC_URL=https://rpc.tiramisu.db-chain.testnet.arkiv.network/<your-api-key>
++ TIRAMISU_API_KEY=your-key-from-hub
 ```
 
 Register an API key at `https://hub.arkiv.network/api-keys` and pass it as a URL path segment, `X-API-KEY` header, or `Authorization: Bearer` header. Without a key, anonymous RPC access is rate-limited.
@@ -98,12 +98,12 @@ These ship together — apply all of them:
 
 ### 5. Refresh funding
 
-- Request fresh test GLM from the [Cheesecake faucet](https://hub.arkiv.network/faucet).
-- No bridge address is published for Cheesecake. Funds on Braga stay there.
+- Request fresh test GLM from the [Tiramisu faucet](https://hub.arkiv.network/faucet).
+- No bridge address is published for Tiramisu. Funds on Braga stay there.
 
 ### 6. Re-create entities and seed data
 
-Braga entities do not migrate. If the app depends on seed data, startup entities, cached indexes, or demo content, run the seed/migration script against Cheesecake before switching traffic.
+Braga entities do not migrate. If the app depends on seed data, startup entities, cached indexes, or demo content, run the seed/migration script against Tiramisu before switching traffic.
 
 ### 7. Verify both read and write paths
 
@@ -111,13 +111,13 @@ After updating:
 
 - Run one write flow end-to-end (`createEntity`)
 - Verify queries return the newly written entity
-- Confirm wallet prompts show Cheesecake, not Braga
+- Confirm wallet prompts show Tiramisu, not Braga
 - Confirm gas is charged in `GLM`
 - Test a partial update with `patchEntity` (not a full replace)
 
 ## Migration Notes for Agents
 
-- Prefer narrow replacements: change active codepaths to Cheesecake, then remove Braga-only compatibility code.
+- Prefer narrow replacements: change active codepaths to Tiramisu, then remove Braga-only compatibility code.
 - Keep Braga references only in migration docs or explicit legacy support blocks.
 - If the codebase uses direct viem or wagmi chain definitions instead of the Arkiv exported chain, update `id`, `rpcUrls`, and `nativeCurrency` consistently.
 - Do not teach users to hand-build raw entity mutation transactions — the SDK handles encoding internally via the Arkiv precompile at `0x4400000000000000000000000000000000000044`.

--- a/skills/arkiv-best-practices/references/migration-guide.md
+++ b/skills/arkiv-best-practices/references/migration-guide.md
@@ -29,9 +29,11 @@ Use this guide when the user already has an Arkiv project that targets Braga and
 Install the dev release — npm `latest` is still 0.7.0:
 
 ```bash
-npm install @arkiv-network/sdk@dev viem
+npm install @arkiv-network/sdk viem
 # or
-bun add @arkiv-network/sdk@dev viem
+pnpm add @arkiv-network/sdk viem 
+# or
+bun add @arkiv-network/sdk viem
 ```
 
 Verify the installed version is `0.8.0-dev.3` or newer.
@@ -94,7 +96,7 @@ These ship together — apply all of them:
 
 **Event handler renames:** `onEntityUpdated` → `onEntityPatched`, `onEntityExpiresInExtended` → `onExpiryExtended`. New: `onOwnershipTransferred`, `onEvent`. `onEntityExpired` is **gone** — expiration fires no event; poll or handle `NoEntityFoundError` from `getEntity()`.
 
-**Query operators:** `ne()`, `exists()`, and `hasType()` are exported by the SDK but **not implemented on the node** — queries using them fail to parse. Use `not(eq(...))` instead.
+**Query operators:** `ne()`, `exists()`, and `hasType()` are exported by the SDK but **not implemented on the node** — queries using them fail to parse. For inequality, use `not(eq(...))` as the not-equal workaround. There is no substitute for `exists()` or `hasType()` today.
 
 ### 5. Refresh funding
 

--- a/skills/arkiv-best-practices/references/sdk-reference.md
+++ b/skills/arkiv-best-practices/references/sdk-reference.md
@@ -1,140 +1,224 @@
 # Arkiv SDK Reference
 
+All examples target `@arkiv-network/sdk@0.8.0-dev.3` on the Cheesecake devnet.
+
 ## TypeScript SDK
 
 ### Installation
 
 ```bash
-# npm
-npm install @arkiv-network/sdk viem
+# npm — install the dev release; npm "latest" is still 0.7.0
+npm install @arkiv-network/sdk@dev viem
 
 # Bun
-bun add @arkiv-network/sdk viem
+bun add @arkiv-network/sdk@dev viem
 ```
 
-Since `0.7.0`, [viem](https://viem.sh) is a **peer dependency** — install it alongside the SDK. The SDK no longer re-exports viem's internals (`http`, `custom`, `privateKeyToAccount`, `Hex`, etc.); import them from `viem` / `viem/accounts` directly.
+[viem](https://viem.sh) is a **peer dependency** — install it alongside the SDK. The SDK no longer re-exports viem's internals (`http`, `custom`, `privateKeyToAccount`, `Hex`, etc.); import them from `viem` / `viem/accounts` directly.
 
-Version minimums to keep in mind before suggesting code:
+### Package exports
 
-- `select()`, viem-style imports, client-side validation, typed errors — SDK `0.7.0+`
-- `braga` chain export — SDK `0.6.5+`
-- On `0.6.x`, `http`/`custom` import from `@arkiv-network/sdk` and `privateKeyToAccount` from `@arkiv-network/sdk/accounts`, and queries use `buildQuery()` with `.withPayload()`/`.withAttributes()`/`.withMetadata()`
+| Subpath | Contents |
+| ------- | -------- |
+| `@arkiv-network/sdk` | Client factories, errors, `ExpirationTime`, payload helpers, re-exports from `/attr`, `/entity` |
+| `@arkiv-network/sdk/chains` | `cheesecake`, `localhost` |
+| `@arkiv-network/sdk/query` | Query operators, `SelectQueryBuilder`, `QueryResult` |
+| `@arkiv-network/sdk/attr` | Typed value helpers: `i32`, `u64`, `u256`, `dec`, `str`, `addr`, `key`, `bytes32`, `bool` |
+| `@arkiv-network/sdk/entity` | `Expiry`, `Lifetime` types |
+| `@arkiv-network/sdk/utils` | `ExpirationTime`, `jsonToPayload`, `stringToPayload` (also available from root) |
+| `@arkiv-network/sdk/types` | Shared type definitions |
 
-Verify the user's installed SDK version. Do not pin install commands unless the user explicitly asks for a specific version.
+There is no `@arkiv-network/sdk/accounts` export.
 
-### Imports (SDK 0.7.0+)
+### Imports
 
 ```typescript
-// Core client factories and typed errors
 import {
   createWalletClient,
   createPublicClient,
-  InvalidAttributeError,
-  InvalidExpirationError,
+  ExpirationTime,
+  jsonToPayload,
+  stringToPayload,
+  InvalidValueError,
+  InvalidExpiryError,
+  EmptyPatchError,
+  ConflictingMutationError,
+  NoEntityFoundError,
 } from "@arkiv-network/sdk"
 
-// Transports and account management come from viem
+import { i32, u64, dec, str, addr } from "@arkiv-network/sdk/attr"
+import { cheesecake } from "@arkiv-network/sdk/chains"
+import { eq, gt, lt, gte, lte, and, or, not, startsWith } from "@arkiv-network/sdk/query"
 import { http, custom } from "viem"
 import { privateKeyToAccount, nonceManager } from "viem/accounts"
-
-// Chain configuration
-import { braga } from "@arkiv-network/sdk/chains"
-
-// Utilities
-import { ExpirationTime, jsonToPayload, stringToPayload, payloadToString } from "@arkiv-network/sdk/utils"
-
-// Query operators and predicates
-import { eq, gt, lt, gte, lte, and, or } from "@arkiv-network/sdk/query"
 ```
 
 ### WalletClient Methods (Write Operations)
 
+All methods accept an optional second argument `txParams?: TxParams` for gas/nonce overrides.
+
 #### createEntity
 
 ```typescript
-const { entityKey, txHash } = await walletClient.createEntity({
-  payload: jsonToPayload({ message: 'Hello' }),
-  contentType: 'application/json',
-  attributes: [
-    { key: 'type', value: 'greeting' },
-    { key: 'priority', value: 5 }
-  ],
-  expiresIn: ExpirationTime.fromHours(12),
+const { entityKey, txHash, expiresAt } = await walletClient.createEntity({
+  payload: jsonToPayload({ message: "Hello" }),
+  contentType: "application/json",
+  attributes: {
+    type: "greeting",
+    priority: i32(5),
+    score: dec("4.5"),
+  },
+  expires: ExpirationTime.fromHours(12),
 })
 ```
 
-#### updateEntity
+Returns: `{ entityKey: Hex, txHash: Hash, expiresAt: bigint }`
 
-**Full replace, not a patch.** The attribute set becomes exactly the provided list; payload, content type, and expiration are overwritten. Omitted attributes are silently removed. To change only some fields, read the entity first (`getEntity`) and re-send the complete state.
+#### patchEntity
+
+**Partial update** — only fields named in `set`/`unset`/`payload`/`contentType` are touched. Entity key, owner, creation flags, and expiry never change via patch (use `extendEntity` / `changeOwnership` for those).
 
 ```typescript
-const { txHash } = await walletClient.updateEntity({
-  entityKey: entityKey,
-  payload: jsonToPayload({ message: 'Updated' }),
-  contentType: 'application/json',
-  attributes: [
-    { key: 'type', value: 'greeting' },
-    { key: 'updated', value: Date.now() }
-  ],
-  expiresIn: ExpirationTime.fromHours(24),
+const { txHash } = await walletClient.patchEntity({
+  entityKey,
+  set: { status: "published", revision: i32(2) },
+  unset: ["draft"],
+  payload: jsonToPayload({ title: "Hello" }),
 })
 ```
+
+Throws `EmptyPatchError` if nothing is passed. Throws `ConflictingMutationError` if a name appears in both `set` and `unset`.
+
+Returns: `{ entityKey: Hex, txHash: Hash }`
 
 #### deleteEntity
 
 ```typescript
-const { txHash } = await walletClient.deleteEntity({
-  entityKey: entityKey
-})
+const { txHash } = await walletClient.deleteEntity({ entityKey })
 ```
+
+Returns: `{ entityKey: Hex, txHash: Hash }`
 
 #### extendEntity
 
 ```typescript
-const { txHash } = await walletClient.extendEntity({
-  entityKey: entityKey,
-  expiresIn: ExpirationTime.fromHours(1), // always use the helper for readability
+const { txHash, expiresAt } = await walletClient.extendEntity({
+  entityKey,
+  expires: ExpirationTime.fromHours(1),
 })
 ```
 
-#### mutateEntities (Batch Operations)
+Returns: `{ entityKey: Hex, txHash: Hash, expiresAt: bigint }`
 
-Performs any number of operations in a **single transaction**. Accepts `creates`, `updates`, `deletes`, `extensions`, and `ownershipChanges` — they can be mixed in one call:
+#### changeOwnership
 
 ```typescript
-await walletClient.mutateEntities({
-  creates: [
-    {
-      payload: stringToPayload('item 1'),
-      contentType: 'text/plain',
-      attributes: [{ key: 'type', value: 'item' }],
-      expiresIn: ExpirationTime.fromMinutes(30),
-    },
-  ],
-  extensions: [
-    { entityKey: '0x456...', expiresIn: ExpirationTime.fromHours(1) },
-  ],
-  deletes: [{ entityKey: '0x321...' }],
+const { txHash } = await walletClient.changeOwnership({
+  entityKey,
+  newOwner: "0xNewOwnerAddress",
 })
 ```
 
-### Validation Rules (SDK 0.7.0+)
+Returns: `{ entityKey: Hex, txHash: Hash }`
 
-The SDK validates mutations client-side and throws a descriptive typed error before anything hits the network:
+#### executeBatch
 
-- **Numeric attribute values must be integers.** A non-integer number throws `InvalidAttributeError`. To store a non-integer, scale it to a fixed precision (`1.5` → `1500`, dividing on read) to keep range queries working — or store it as a string, which only supports equality.
-- **`expiresIn` must be a positive integer and a multiple of 2 seconds.** Arkiv measures expiration in whole blocks (1 block = 2 seconds); invalid values throw `InvalidExpirationError`. The `ExpirationTime` helpers always produce valid values.
+Applies any combination of creates, patches, deletes, extensions, and ownership changes **atomically in one transaction**:
 
 ```typescript
-import { InvalidAttributeError, InvalidExpirationError } from "@arkiv-network/sdk"
+const result = await walletClient.executeBatch({
+  creates: [{
+    payload: stringToPayload("item 1"),
+    contentType: "text/plain",
+    attributes: { type: "item" },
+    expires: ExpirationTime.fromMinutes(30),
+  }],
+  patches: [{ entityKey, set: { status: "done" } }],
+  extensions: [{ entityKey: "0x456...", expires: ExpirationTime.fromHours(1) }],
+  deletes: [{ entityKey: "0x321..." }],
+  ownershipChanges: [{ entityKey: "0x789...", newOwner: "0xNew..." }],
+})
+```
+
+Returns: `{ txHash, createdEntities, patchedEntities, deletedEntities, extendedEntities, ownershipChanges }`
+
+### Typed Attributes
+
+Attributes are passed as an **object keyed by name**:
+
+```typescript
+attributes: {
+  category: "docs",           // bare string → str
+  level: i32(10),             // explicit i32
+  balance: u256(1_000_000n),  // explicit u256
+  price: dec("19.99"),        // genuine decimal
+  owner: addr("0xAbC..."),    // checksummed address
+  flagged: true,              // bare boolean → bool
+}
+```
+
+Bare-form defaults: `boolean` → `bool`, `number` → `i32`, `bigint` → `u256`, `string` → `str`.
+
+**Validation rules:**
+
+- Attribute names: 1–32 bytes, start with a letter, chars `[A-Za-z0-9._-]`, no `$` prefix, no `--`, not a reserved word
+- Max 32 attributes per operation
+- Max payload 128 KiB
+- `str` max 128 UTF-8 bytes
+- A bare float like `19.99` throws `InvalidValueError` — use `dec("19.99")`
+
+Reading attributes: `entity.attributes` is an object keyed by name, each value is `{ type, value }`:
+
+```typescript
+entity.attributes.priority?.value  // the raw value
+entity.attributes.priority?.type   // "i32"
+```
+
+### ExpirationTime Helpers
+
+Expiration uses the `expires: Expiry` parameter (not `expiresIn`):
+
+```typescript
+// Relative lifetimes
+ExpirationTime.fromSeconds(30)
+ExpirationTime.fromMinutes(30)
+ExpirationTime.fromHours(1)
+ExpirationTime.fromHours(12)
+ExpirationTime.fromHours(24)
+ExpirationTime.fromDays(7)
+ExpirationTime.fromWeeks(2)
+ExpirationTime.fromMonths(3)
+ExpirationTime.fromYears(1)
+ExpirationTime.fromBlocks(100)
+
+// Absolute deadlines
+ExpirationTime.atBlock(1_200_000n)
+ExpirationTime.atDate(new Date("2027-01-01"))
+ExpirationTime.permanent()
+```
+
+### Validation Rules
+
+The SDK validates mutations client-side and throws typed errors before anything hits the network:
+
+```typescript
+import {
+  InvalidValueError,
+  InvalidExpiryError,
+  InvalidAttributeNameError,
+  EmptyPatchError,
+  ConflictingMutationError,
+} from "@arkiv-network/sdk"
 
 try {
   await walletClient.createEntity({ /* ... */ })
 } catch (error) {
-  if (error instanceof InvalidAttributeError) {
-    // a numeric attribute value was not an integer
-  } else if (error instanceof InvalidExpirationError) {
-    // expiresIn was not a positive multiple of the 2s block time
+  if (error instanceof InvalidValueError) {
+    // a value did not match its declared type
+  } else if (error instanceof InvalidExpiryError) {
+    // invalid expiry configuration
+  } else if (error instanceof InvalidAttributeNameError) {
+    // attribute name violates grammar rules
   } else {
     throw error
   }
@@ -146,7 +230,7 @@ try {
 All transactions from one wallet must use strictly sequential nonces, and the SDK does not manage nonces — each write fetches the next nonce from the network at send time. Two writes in flight simultaneously fetch the **same** nonce and collide.
 
 ```typescript
-// ❌ Both writes fetch the same nonce — one fails or gets replaced
+// Both writes fetch the same nonce — one fails or gets replaced
 await Promise.all([
   walletClient.createEntity({ /* ... */ }),
   walletClient.createEntity({ /* ... */ }),
@@ -155,25 +239,17 @@ await Promise.all([
 
 Two safe options:
 
-1. **Batch into a single transaction (preferred):** `mutateEntities()` — one transaction, one nonce.
+1. **Batch into a single transaction (preferred):** `executeBatch()` — one transaction, one nonce.
 2. **viem's nonce manager** when separate transactions are unavoidable:
 
 ```typescript
-import { privateKeyToAccount, nonceManager } from "viem/accounts"
-
 const walletClient = createWalletClient({
-  chain: braga,
-  transport: http(),
+  chain: cheesecake,
+  transport: http(process.env.CHEESECAKE_RPC_URL),
   account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`, {
     nonceManager,
   }),
 })
-
-// ✅ Safe — nonces are allocated locally and sequentially
-await Promise.all([
-  walletClient.createEntity({ /* ... */ }),
-  walletClient.createEntity({ /* ... */ }),
-])
 ```
 
 A nonce manager only coordinates writes **within a single process**. Multiple processes writing with the same private key still collide — give each writer its own wallet, or route all writes through one process.
@@ -187,21 +263,16 @@ A nonce manager only coordinates writes **within a single process**. Multiple pr
 ```typescript
 const result = await publicClient
   .select({ key: true, payload: true, attributes: true })
-  .where(eq('type', 'note'), gt('created', 1672531200))
+  .where(eq("type", "note"), gt("created", i32(Date.now() - 86400000)))
   .limit(10)
   .fetch()
 ```
 
-Available fields: `key`, `owner`, `creator`, `contentType`, `payload`, `attributes`, `expiresAtBlock`, `createdAtBlock`, `lastModifiedAtBlock`, `transactionIndexInBlock`, `operationIndexInTransaction`.
+Available fields: `key`, `owner`, `creator`, `createdAt`, `updatedAt`, `expiresAt`, `creationFlags`, `contentType`, `payload`, `attributeSchema`, `attributes`.
 
 - `select()` with no argument (or `"*"`) fetches every field — fine for prototyping, wasteful in production.
 - The result type is inferred from the selection: `entity.toJson()` / `entity.toText()` exist only when `payload` is selected; accessing an unselected field is a compile error.
-- Pass the selection **inline**. A selection stored in a variable widens `true` to `boolean` and the result type can't be narrowed. To reuse one, annotate it `as const`:
-
-```typescript
-const fields = { owner: true, payload: true } as const
-await publicClient.select(fields).where(eq('type', 'note')).fetch()
-```
+- Pass the selection **inline**. A selection stored in a variable widens `true` to `boolean` and the result type can't be narrowed. To reuse one, annotate it `as const`.
 
 Query builder methods:
 
@@ -209,13 +280,22 @@ Query builder methods:
 - `.ownedBy(address)` — Filter by current owner address (can change over time)
 - `.createdBy(address)` — Filter by original creator address (immutable)
 - `.limit(n)` — Limit number of results (max 200 per page)
+- `.cursor(cursor)` — Resume from a previous page's cursor
+- `.atBlock(block)` — Query at a specific block
 - `.fetch()` — Execute the query
+- `[Symbol.asyncIterator]` — Async generator over all pages
 
-On SDK `0.6.x`, use `buildQuery()` with `.withPayload(true)` / `.withAttributes(true)` / `.withMetadata(true)` instead of `select()`.
+Pagination:
+
+```typescript
+if (result.hasNextPage()) {
+  const nextPage = await result.next()
+}
+```
 
 #### Ordering
 
-Results always come back **newest first**; server-side ordering is not supported. `orderBy()` and the `asc()` / `desc()` helpers are deprecated no-ops since 0.7.0 — sort the fetched entities in JavaScript instead. Note that `.limit(n)` caps results *before* a client-side sort (it returns the n newest matches, not the top n by your attribute).
+Results always come back **newest first**; server-side ordering is not supported. `orderBy()`, `asc()`, and `desc()` were removed in 0.8 — sort the fetched entities in JavaScript instead. Note that `.limit(n)` caps results *before* a client-side sort (it returns the n newest matches, not the top n by your attribute).
 
 #### getEntity
 
@@ -225,86 +305,106 @@ const data = entity.toJson()   // Parse JSON payload
 const text = entity.toText()   // Get text payload
 ```
 
-### ExpirationTime Helpers
-
-Expiration is expressed in **seconds**. Always use these helpers to convert human-readable durations:
-
-```typescript
-ExpirationTime.fromMinutes(30)  // 1800 seconds
-ExpirationTime.fromHours(1)     // 3600 seconds
-ExpirationTime.fromHours(12)    // 43200 seconds
-ExpirationTime.fromHours(24)    // 86400 seconds
-ExpirationTime.fromDays(7)      // 604800 seconds
-```
-
-**Always prefer the helpers over raw numbers for `expiresIn`** — they're more readable, less error-prone, and guaranteed to satisfy the positive-multiple-of-2 validation rule. If a raw number is passed, it is treated as seconds (e.g., `expiresIn: 3600` means 1 hour) and must be a positive multiple of 2.
+Throws `NoEntityFoundError` if the entity does not exist or has expired.
 
 ### Payload Helpers
 
 ```typescript
-import { jsonToPayload, stringToPayload, payloadToString } from "@arkiv-network/sdk/utils"
+import { jsonToPayload, stringToPayload } from "@arkiv-network/sdk"
 
-// JSON data
 const jsonPayload = jsonToPayload({ key: "value" })
-
-// Plain text
 const textPayload = stringToPayload("Hello Arkiv!")
 
-// Reading back
-const text = payloadToString(entity.payload)
-const data = JSON.parse(payloadToString(entity.payload))
-// or use entity helper (requires payload to be selected)
+// Reading back (requires payload to be selected in the query)
+const text = entity.toText()
 const data = entity.toJson()
 ```
+
+`payloadToString` was removed in 0.8 — use `entity.toText()` / `entity.toJson()` instead.
 
 ### Query Operators
 
 ```typescript
-import { eq, gt, lt, gte, lte, and, or } from "@arkiv-network/sdk/query"
+import { eq, gt, lt, gte, lte, and, or, not, startsWith } from "@arkiv-network/sdk/query"
 
-eq('type', 'note')        // type = "note"
-gt('priority', 3)          // priority > 3
-lt('price', 1000)          // price < 1000
-gte('created', timestamp)  // created >= timestamp
-lte('expiration', limit)   // expiration <= limit
+eq("type", "note")              // type = str('note')
+gt("priority", i32(3))          // priority > i32(3)
+lt("price", i32(1000))          // price < i32(1000)
+gte("created", i32(timestamp))  // created >= i32(timestamp)
+lte("expiresAt", u64(limit))    // expiresAt <= u64(limit)
+startsWith("name", "test")      // name STARTSWITH str('test')
+not(eq("status", "deleted"))    // NOT status = str('deleted')
 ```
 
-String attributes only support `eq()`. Numeric attributes support all comparison operators (and values must be integers).
+String attributes only support `eq()` and `startsWith()`. Numeric attributes support all comparison operators.
 
-Nest conditions with `and()` / `or()` — both accept predicates as varargs or a single array:
+**Caution:** `ne()`, `exists()`, and `hasType()` are exported by the SDK but **not implemented on the node** — queries using them fail to parse. Use `not(eq(...))` as the not-equal workaround. It matches the full complement, including entities that never set the attribute.
+
+Nest conditions with `and()` / `or()`:
 
 ```typescript
-// type = "note" AND (priority > 3 OR pinned = "true")
 await publicClient
   .select({ key: true, payload: true })
-  .where(eq('type', 'note'), or(gt('priority', 3), eq('pinned', 'true')))
+  .where(eq("type", "note"), or(gt("priority", i32(3)), eq("pinned", "true")))
   .fetch()
-
-// Array form works too: or([gt('priority', 3), eq('pinned', 'true')])
 ```
 
-Glob matching on string attributes (`~`) exists at the protocol level but is not yet exposed in the TypeScript SDK — use the JSON-RPC API directly if you need it (see `api-reference.md`).
+For prefix matching on string attributes, use `startsWith()` or the raw JSON-RPC API (see `api-reference.md`).
+
+### watchEntityEvents
+
+Live event subscription. Returns an unwatch function directly — **do not await it**:
+
+```typescript
+const unwatch = publicClient.watchEntityEvents({
+  onEntityCreated: (event) => {
+    // { type: "EntityCreated", entityKey, owner, expiresAt, creationFlags, blockNumber, transactionHash, logIndex }
+  },
+  onEntityPatched: (event) => {
+    // { type: "EntityPatched", entityKey, owner, blockNumber, transactionHash, logIndex }
+  },
+  onExpiryExtended: (event) => {
+    // { type: "ExpiryExtended", entityKey, owner, expiresAt, blockNumber, transactionHash, logIndex }
+  },
+  onOwnershipTransferred: (event) => {
+    // { type: "OwnershipTransferred", entityKey, previousOwner, newOwner, blockNumber, transactionHash, logIndex }
+  },
+  onEntityDeleted: (event) => {
+    // { type: "EntityDeleted", entityKey, owner, blockNumber, transactionHash, logIndex }
+  },
+  onEvent: (event) => {
+    // Catch-all — runs before per-type handlers
+  },
+  onError: (error) => console.error(error),
+  fromBlock: 1_000_000n,
+  pollingInterval: 1000,
+})
+
+// Later: stop watching
+unwatch()
+```
+
+**Important:** `onEntityExpired` no longer exists — expiration fires no event. Poll with `getEntity()` and handle `NoEntityFoundError`, or query for entities approaching expiry via `$expiresAt`.
+
+Every event carries `{ blockNumber, transactionHash, logIndex }`. The old `cost`/`oldExpirationBlock`/`newExpirationBlock` fields are gone.
 
 ### Browser Usage with MetaMask
 
 ```typescript
 import { createWalletClient, createPublicClient } from "@arkiv-network/sdk"
-import { braga } from "@arkiv-network/sdk/chains"
+import { cheesecake } from "@arkiv-network/sdk/chains"
 import { custom, http } from "viem"
 
-// Request wallet connection
-await window.ethereum.request({ method: 'eth_requestAccounts' })
+await window.ethereum.request({ method: "eth_requestAccounts" })
 
-// Use MetaMask as transport (no private key needed)
 const walletClient = createWalletClient({
-  chain: braga,
+  chain: cheesecake,
   transport: custom(window.ethereum),
 })
 
-// Public client for queries
 const publicClient = createPublicClient({
-  chain: braga,
-  transport: http(),
+  chain: cheesecake,
+  transport: http(process.env.CHEESECAKE_RPC_URL),
 })
 ```
 
@@ -312,26 +412,26 @@ const publicClient = createPublicClient({
 
 ```typescript
 await window.ethereum.request({
-  method: 'wallet_addEthereumChain',
+  method: "wallet_addEthereumChain",
   params: [{
-    chainId: '0xe0087f86e',
-    chainName: 'Arkiv Braga Testnet',
-    nativeCurrency: { name: 'GLM', symbol: 'GLM', decimals: 18 },
-    rpcUrls: ['https://braga.hoodi.arkiv.network/rpc'],
-    blockExplorerUrls: ['https://explorer.braga.hoodi.arkiv.network']
-  }]
+    chainId: "0x75ff6e",
+    chainName: "Arkiv Cheesecake Testnet",
+    nativeCurrency: { name: "GLM", symbol: "GLM", decimals: 18 },
+    rpcUrls: ["https://rpc.cheesecake.db-chain.devnet.gobas.me"],
+    blockExplorerUrls: ["https://indexer.cheesecake.db-chain.devnet.gobas.me"],
+  }],
 })
 ```
 
 ### Browser CDN Imports
 
-For static HTML/JS pages without a bundler (note that `http` comes from viem's CDN build):
+For static HTML/JS pages without a bundler:
 
 ```javascript
-import { createPublicClient } from 'https://esm.sh/@arkiv-network/sdk?target=es2022&bundle-deps'
-import { eq } from 'https://esm.sh/@arkiv-network/sdk/query?target=es2022&bundle-deps'
-import { braga } from 'https://esm.sh/@arkiv-network/sdk/chains?target=es2022&bundle-deps'
+import { createPublicClient } from 'https://esm.sh/@arkiv-network/sdk@0.8.0-dev.3?target=es2022&bundle-deps'
+import { eq } from 'https://esm.sh/@arkiv-network/sdk/query@0.8.0-dev.3?target=es2022&bundle-deps'
+import { cheesecake } from 'https://esm.sh/@arkiv-network/sdk/chains@0.8.0-dev.3?target=es2022&bundle-deps'
 import { http } from 'https://esm.sh/viem?target=es2022'
 ```
 
-If the user is working with a versioned CDN URL instead of the unpinned form above, make sure the selected SDK version supports what the code uses: `0.6.5+` for the `braga` import, `0.7.0+` for `select()` and viem-based imports.
+Pin the version in CDN URLs — the `cheesecake` chain export and `select()` require 0.8.0-dev.3+.

--- a/skills/arkiv-best-practices/references/sdk-reference.md
+++ b/skills/arkiv-best-practices/references/sdk-reference.md
@@ -7,11 +7,14 @@ All examples target `@arkiv-network/sdk@0.8.0-dev.3` on the Tiramisu testnet.
 ### Installation
 
 ```bash
-# npm — install the dev release; npm "latest" is still 0.7.0
-npm install @arkiv-network/sdk@dev viem
+# npm — install the latest release
+npm install @arkiv-network/sdk viem
+
+# pnpm
+bun add @arkiv-network/sdk viem
 
 # Bun
-bun add @arkiv-network/sdk@dev viem
+bun add @arkiv-network/sdk viem
 ```
 
 [viem](https://viem.sh) is a **peer dependency** — install it alongside the SDK. The SDK no longer re-exports viem's internals (`http`, `custom`, `privateKeyToAccount`, `Hex`, etc.); import them from `viem` / `viem/accounts` directly.
@@ -404,7 +407,7 @@ const walletClient = createWalletClient({
 
 const publicClient = createPublicClient({
   chain: tiramisu,
-  transport: http(process.env.TIRAMISU_RPC_URL),
+  transport: http(tiramisu.rpcUrls.default.http),
 })
 ```
 

--- a/skills/arkiv-best-practices/references/sdk-reference.md
+++ b/skills/arkiv-best-practices/references/sdk-reference.md
@@ -1,6 +1,6 @@
 # Arkiv SDK Reference
 
-All examples target `@arkiv-network/sdk@0.8.0-dev.3` on the Cheesecake devnet.
+All examples target `@arkiv-network/sdk@0.8.0-dev.3` on the Tiramisu testnet.
 
 ## TypeScript SDK
 
@@ -21,7 +21,7 @@ bun add @arkiv-network/sdk@dev viem
 | Subpath | Contents |
 | ------- | -------- |
 | `@arkiv-network/sdk` | Client factories, errors, `ExpirationTime`, payload helpers, re-exports from `/attr`, `/entity` |
-| `@arkiv-network/sdk/chains` | `cheesecake`, `localhost` |
+| `@arkiv-network/sdk/chains` | `tiramisu`, `localhost` |
 | `@arkiv-network/sdk/query` | Query operators, `SelectQueryBuilder`, `QueryResult` |
 | `@arkiv-network/sdk/attr` | Typed value helpers: `i32`, `u64`, `u256`, `dec`, `str`, `addr`, `key`, `bytes32`, `bool` |
 | `@arkiv-network/sdk/entity` | `Expiry`, `Lifetime` types |
@@ -47,7 +47,7 @@ import {
 } from "@arkiv-network/sdk"
 
 import { i32, u64, dec, str, addr } from "@arkiv-network/sdk/attr"
-import { cheesecake } from "@arkiv-network/sdk/chains"
+import { tiramisu } from "@arkiv-network/sdk/chains"
 import { eq, gt, lt, gte, lte, and, or, not, startsWith } from "@arkiv-network/sdk/query"
 import { http, custom } from "viem"
 import { privateKeyToAccount, nonceManager } from "viem/accounts"
@@ -244,8 +244,8 @@ Two safe options:
 
 ```typescript
 const walletClient = createWalletClient({
-  chain: cheesecake,
-  transport: http(process.env.CHEESECAKE_RPC_URL),
+  chain: tiramisu,
+  transport: http(process.env.TIRAMISU_RPC_URL),
   account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`, {
     nonceManager,
   }),
@@ -392,19 +392,19 @@ Every event carries `{ blockNumber, transactionHash, logIndex }`. The old `cost`
 
 ```typescript
 import { createWalletClient, createPublicClient } from "@arkiv-network/sdk"
-import { cheesecake } from "@arkiv-network/sdk/chains"
+import { tiramisu } from "@arkiv-network/sdk/chains"
 import { custom, http } from "viem"
 
 await window.ethereum.request({ method: "eth_requestAccounts" })
 
 const walletClient = createWalletClient({
-  chain: cheesecake,
+  chain: tiramisu,
   transport: custom(window.ethereum),
 })
 
 const publicClient = createPublicClient({
-  chain: cheesecake,
-  transport: http(process.env.CHEESECAKE_RPC_URL),
+  chain: tiramisu,
+  transport: http(process.env.TIRAMISU_RPC_URL),
 })
 ```
 
@@ -414,11 +414,11 @@ const publicClient = createPublicClient({
 await window.ethereum.request({
   method: "wallet_addEthereumChain",
   params: [{
-    chainId: "0x75ff6e",
-    chainName: "Arkiv Cheesecake Testnet",
+    chainId: "0x7614d1",
+    chainName: "Arkiv Tiramisu Testnet",
     nativeCurrency: { name: "GLM", symbol: "GLM", decimals: 18 },
-    rpcUrls: ["https://rpc.cheesecake.db-chain.devnet.gobas.me"],
-    blockExplorerUrls: ["https://indexer.cheesecake.db-chain.devnet.gobas.me"],
+    rpcUrls: ["https://rpc.tiramisu.db-chain.testnet.arkiv.network"],
+    blockExplorerUrls: ["https://indexer.tiramisu.db-chain.testnet.arkiv.network"],
   }],
 })
 ```
@@ -430,8 +430,8 @@ For static HTML/JS pages without a bundler:
 ```javascript
 import { createPublicClient } from 'https://esm.sh/@arkiv-network/sdk@0.8.0-dev.3?target=es2022&bundle-deps'
 import { eq } from 'https://esm.sh/@arkiv-network/sdk/query@0.8.0-dev.3?target=es2022&bundle-deps'
-import { cheesecake } from 'https://esm.sh/@arkiv-network/sdk/chains@0.8.0-dev.3?target=es2022&bundle-deps'
+import { tiramisu } from 'https://esm.sh/@arkiv-network/sdk/chains@0.8.0-dev.3?target=es2022&bundle-deps'
 import { http } from 'https://esm.sh/viem?target=es2022'
 ```
 
-Pin the version in CDN URLs — the `cheesecake` chain export and `select()` require 0.8.0-dev.3+.
+Pin the version in CDN URLs — the `tiramisu` chain export and `select()` require 0.8.0-dev.3+.

--- a/skills/arkiv-feedback/SKILL.md
+++ b/skills/arkiv-feedback/SKILL.md
@@ -14,7 +14,7 @@ The skill mirrors the two GitHub issue forms hosted on the repo (`1-bug.yml`, `2
 Trigger on any of these signals from the user:
 
 - "I want to report a bug in Arkiv" / "file an issue" / "Arkiv is broken"
-- "the network is down" / "the SDK is throwing X" / "Kaolin/Braga is unreachable"
+- "the network is down" / "the SDK is throwing X" / "Cheesecake is unreachable"
 - "I have an idea for Arkiv" / "I'd like a feature" / "Arkiv should support X"
 
 Do **not** invoke for:

--- a/skills/arkiv-feedback/SKILL.md
+++ b/skills/arkiv-feedback/SKILL.md
@@ -14,7 +14,7 @@ The skill mirrors the two GitHub issue forms hosted on the repo (`1-bug.yml`, `2
 Trigger on any of these signals from the user:
 
 - "I want to report a bug in Arkiv" / "file an issue" / "Arkiv is broken"
-- "the network is down" / "the SDK is throwing X" / "Cheesecake is unreachable"
+- "the network is down" / "the SDK is throwing X" / "Tiramisu is unreachable"
 - "I have an idea for Arkiv" / "I'd like a feature" / "Arkiv should support X"
 
 Do **not** invoke for:

--- a/skills/arkiv-feedback/references/bug-form.md
+++ b/skills/arkiv-feedback/references/bug-form.md
@@ -2,6 +2,8 @@
 
 Mirrors `Arkiv-Network/reported-issues/.github/ISSUE_TEMPLATE/1-bug.yml`. If that file changes, update this reference too.
 
+**Upstream drift:** the upstream `1-bug.yml` DB-chain dropdown still lists only Kaolin / Braga / Local / Other — it does not yet include Cheesecake. This skill adds Cheesecake as the first option so agents default to the current network. When upstream adds Cheesecake, keep this reference aligned.
+
 ## Form metadata
 
 - **Title prefix:** `[Bug]: `
@@ -17,7 +19,7 @@ Ask each in this sequence. `R` = required, `O` = optional.
 | 1 | Contact                        | Text      | O   | Discord handle, email, or GitHub username for follow-up.              |
 | 2 | DB-chain                       | Dropdown  | R   | Options below. Default to first if user is unsure.                    |
 | 3 | Surface                        | Dropdown  | R   | Options below.                                                        |
-| 4 | SDK / tool version             | Text      | O   | E.g. `@arkiv-network/sdk@0.6.5`.                                       |
+| 4 | SDK / tool version             | Text      | O   | E.g. `@arkiv-network/sdk@0.8.0-dev.3`.                               |
 | 5 | What happened?                 | Multiline | R   | What they did, expected, and actually saw.                            |
 | 6 | Steps to reproduce             | Multiline | R   | Minimal repro a teammate could follow.                                |
 | 7 | Logs                           | Multiline | O   | Render inside a ` ```shell ... ``` ` block when provided.              |
@@ -26,19 +28,21 @@ Ask each in this sequence. `R` = required, `O` = optional.
 
 ### DB-chain options
 
-1. Kaolin (testnet)
-2. Braga (testnet)
-3. Local / devnet
-4. Other (please describe in the steps)
+1. Cheesecake (testnet)
+2. Braga (testnet) — retired 12 August 2026
+3. Kaolin (testnet) — retired
+4. Local / devnet
+5. Other (please describe in the steps)
 
 ### Surface options
 
 1. SDK (`@arkiv-network/sdk`)
 2. CLI / tooling
 3. Block explorer
-4. Documentation
-5. Website
-6. Other
+4. Entity Explorer (data.arkiv.network)
+5. Documentation
+6. Website
+7. Other
 
 ## Body template
 

--- a/skills/arkiv-feedback/references/bug-form.md
+++ b/skills/arkiv-feedback/references/bug-form.md
@@ -2,7 +2,7 @@
 
 Mirrors `Arkiv-Network/reported-issues/.github/ISSUE_TEMPLATE/1-bug.yml`. If that file changes, update this reference too.
 
-**Upstream drift:** the upstream `1-bug.yml` DB-chain dropdown still lists only Kaolin / Braga / Local / Other — it does not yet include Cheesecake. This skill adds Cheesecake as the first option so agents default to the current network. When upstream adds Cheesecake, keep this reference aligned.
+**Upstream drift:** the upstream `1-bug.yml` DB-chain dropdown still lists only Kaolin / Braga / Local / Other — it does not yet include Tiramisu. This skill adds Tiramisu as the first option so agents default to the current network. When upstream adds Tiramisu, keep this reference aligned.
 
 ## Form metadata
 
@@ -28,7 +28,7 @@ Ask each in this sequence. `R` = required, `O` = optional.
 
 ### DB-chain options
 
-1. Cheesecake (testnet)
+1. Tiramisu (testnet)
 2. Braga (testnet) — retired 12 August 2026
 3. Kaolin (testnet) — retired
 4. Local / devnet


### PR DESCRIPTION
# What does this PR introduce?

Resolves #11 

- Update all references of networks from Braga to Tiramisu (including RPC URLs, faucet links, chain IDs, and imports)
- Update code snippets for v0.8.x breaking changes
- Update migration guide to migrate from Braga to Tiramisu